### PR TITLE
Update methods.jl to fix molecular weights calculation

### DIFF
--- a/src/methods/methods.jl
+++ b/src/methods/methods.jl
@@ -1,4 +1,4 @@
-molecular_weight(model::EoSModel,z = @SVector [1.]) = 0.001*mapreduce(+,*,mw(model),z)
+molecular_weight(model::EoSModel,z = @SVector [1.]) = 0.001*mapreduce(*,+,mw(model),z)
 mw(model::EoSModel) = paramvals(model.params.Mw)
 
 include("initial_guess.jl")


### PR DESCRIPTION
Fixing the molecular weight calculation. Updated the mapreduce function call with the correct order of operators, * and +