### PR TITLE
Cubic (mixing) optimization

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Clapeyron"
 uuid = "7c7805af-46cc-48c9-995b-ed0ed2dc909a"
 authors = ["Hon Wa Yew <yewhonwa@gmail.com>", "Pierre Walker <pwalker@mit.edu>", "Andrés Riedemann <andres.riedemann@gmail.com>"]
-version = "0.2.8"
+version = "0.2.9"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/src/Clapeyron.jl
+++ b/src/Clapeyron.jl
@@ -56,6 +56,7 @@ include("models/eos/SAFT/BACKSAFT/BACKSAFT.jl")
 
 include("models/eos/SAFT/equations.jl")
 
+include("models/eos/cubic/equations.jl")
 include("models/eos/cubic/vdW.jl")
 include("models/eos/cubic/RK/RK.jl")
 include("models/eos/cubic/PR/PR.jl")
@@ -80,7 +81,6 @@ include("models/eos/cubic/PR/variants/PR78.jl")
 include("models/eos/cubic/PR/variants/VTPR.jl")
 include("models/eos/cubic/PR/variants/UMRPR.jl")
 
-include("models/eos/cubic/equations.jl")
 include("models/eos/Activity/equations.jl")
 
 include("models/eos/EmpiricHelmholtz/IAPWS95.jl")

--- a/src/models/eos/cubic/PR/PR.jl
+++ b/src/models/eos/cubic/PR/PR.jl
@@ -38,34 +38,22 @@ function PR(components::Vector{String}; idealmodel=BasicIdeal,
      verbose=false)
     params = getparams(components, ["properties/critical.csv", "properties/molarmass.csv","SAFT/PCSAFT/PCSAFT_unlike.csv"]; userlocations=userlocations, verbose=verbose)
     k  = params["k"]
-    _pc = params["pc"]
-    pc = _pc.values
+    pc = params["pc"]
     Mw = params["Mw"]
-    _Tc = params["Tc"]
-    Tc = _Tc.values
-    Ωa, Ωb = ab_consts(PR)
-    
+    Tc = params["Tc"]
     init_mixing = init_model(mixing,components,activity,mixing_userlocations,activity_userlocations,verbose)
-    a,b = ab_premixing(PR,init_mixing,_Tc,_pc,k)
+    a,b = ab_premixing(PR,init_mixing,Tc,pc,k)
     init_idealmodel = init_model(idealmodel,components,ideal_userlocations,verbose)
     init_alpha = init_model(alpha,components,alpha_userlocations,verbose)
     init_translation = init_model(translation,components,translation_userlocations,verbose)
-
     icomponents = 1:length(components)
-    packagedparams = PRParam(a, b, params["Tc"],_pc,Mw)
+    packagedparams = PRParam(a,b,Tc,pc,Mw)
     references = String[]
     model = PR(components,icomponents,init_alpha,init_mixing,init_translation,packagedparams,init_idealmodel,1e-12,references)
     return model
 end
 
-function ab_premixing(::Type{PR},mixing,Tc,pc,kij)
-    Ωa, Ωb = ab_consts(PR)
-    _Tc = Tc.values
-    _pc = pc.values
-    a = epsilon_LorentzBerthelot(SingleParam(pc, @. Ωa*R̄^2*_Tc^2/_pc),kij)
-    b = sigma_LorentzBerthelot(SingleParam(pc, @. Ωb*R̄*_Tc/_pc))
-    return a,b
-end
+
 
 
 function ab_consts(::Type{<:PRModel})

--- a/src/models/eos/cubic/PR/PR.jl
+++ b/src/models/eos/cubic/PR/PR.jl
@@ -44,13 +44,11 @@ function PR(components::Vector{String}; idealmodel=BasicIdeal,
     _Tc = params["Tc"]
     Tc = _Tc.values
     Ωa, Ωb = ab_consts(PR)
-    a = epsilon_LorentzBerthelot(SingleParam(params["pc"], @. Ωa*R̄^2*Tc^2/pc),k)
-    #check if this is correct in the general case.
-    b = sigma_LorentzBerthelot(SingleParam(params["pc"], @. Ωb*R̄*Tc/pc))
     
+    init_mixing = init_model(mixing,components,activity,mixing_userlocations,activity_userlocations,verbose)
+    a,b = ab_premixing(PR,init_mixing,_Tc,_pc,k)
     init_idealmodel = init_model(idealmodel,components,ideal_userlocations,verbose)
     init_alpha = init_model(alpha,components,alpha_userlocations,verbose)
-    init_mixing = init_model(mixing,components,activity,mixing_userlocations,activity_userlocations,verbose)
     init_translation = init_model(translation,components,translation_userlocations,verbose)
 
     icomponents = 1:length(components)
@@ -58,6 +56,15 @@ function PR(components::Vector{String}; idealmodel=BasicIdeal,
     references = String[]
     model = PR(components,icomponents,init_alpha,init_mixing,init_translation,packagedparams,init_idealmodel,1e-12,references)
     return model
+end
+
+function ab_premixing(::Type{PR},mixing,Tc,pc,kij)
+    Ωa, Ωb = ab_consts(PR)
+    _Tc = Tc.values
+    _pc = pc.values
+    a = epsilon_LorentzBerthelot(SingleParam(pc, @. Ωa*R̄^2*_Tc^2/_pc),kij)
+    b = sigma_LorentzBerthelot(SingleParam(pc, @. Ωb*R̄*_Tc/_pc))
+    return a,b
 end
 
 

--- a/src/models/eos/cubic/equations.jl
+++ b/src/models/eos/cubic/equations.jl
@@ -1,3 +1,12 @@
+function ab_premixing(::Type{T},mixing,Tc,pc,kij) where T <: ABCubicModel
+    Ωa, Ωb = ab_consts(T)
+    _Tc = Tc.values
+    _pc = pc.values
+    a = epsilon_LorentzBerthelot(SingleParam(pc, @. Ωa*R̄^2*_Tc^2/_pc),kij)
+    b = sigma_LorentzBerthelot(SingleParam(pc, @. Ωb*R̄*_Tc/_pc))
+    return a,b
+end
+
 function cubic_ab(model::ABCubicModel,V,T,z=SA[1.0],n=sum(z))
     invn2 = (one(n)/n)^2
     a = model.params.a.values

--- a/src/models/eos/cubic/mixing/Kay.jl
+++ b/src/models/eos/cubic/mixing/Kay.jl
@@ -19,8 +19,28 @@ function mixing_rule(model::ABCubicModel,V,T,z,mixing_model::KayRuleModel,α,a,b
     n = sum(z)
     invn2 = (one(n)/n)^2
     c̄ = dot(z,c)/n
-    b̄ = (dot(z,Symmetric(b.^(1/3)),z) * invn2).^3
-    ā = √(dot(z,Symmetric(a .* sqrt.(α*α') ./ b).^2,z)* invn2)  * b̄
+    #b̄ = (dot(z,Symmetric(b.^(1/3)),z) * invn2).^3
+    #ā = √(dot(z,Symmetric(a .* sqrt.(α*α') ./ b).^2,z)* invn2)  * b̄
+    
+    b̄ = zero(eltype(z))
+    for i in 1:length(z)
+        zi = z[i]
+        b̄ += (cbrt(b[i,i])*invn2*zi^2)^3
+        for j in 1:(i-1)
+            b̄ += 2*(cbrt(b[i,j])*invn2*zi*z[j])^3
+        end
+    end
+
+    ā = zero(eltype(α))+zero(eltype(z))
+    for i in 1:length(z)
+        zi = z[i]
+        αi = α[i]
+        ā += a[i,i]*αi/b[i,i]*zi*b̄
+        for j in 1:(i-1)
+            ā += 2*sqrt(zi*z[j]*invn2*(a[i,j]*sqrt(αi*α[j])/b[i,j])^2)*b̄
+        end
+    end
+    ā
     return ā,b̄,c̄
 end
 

--- a/src/models/eos/cubic/mixing/Kay.jl
+++ b/src/models/eos/cubic/mixing/Kay.jl
@@ -17,30 +17,29 @@ end
 
 function mixing_rule(model::ABCubicModel,V,T,z,mixing_model::KayRuleModel,α,a,b,c)
     n = sum(z)
-    invn2 = (one(n)/n)^2
-    c̄ = dot(z,c)/n
+    invn = (one(n)/n)
+    invn2 = invn^2
     #b̄ = (dot(z,Symmetric(b.^(1/3)),z) * invn2).^3
     #ā = √(dot(z,Symmetric(a .* sqrt.(α*α') ./ b).^2,z)* invn2)  * b̄
-    
     b̄ = zero(eltype(z))
+    ab2 = zero(T+first(z))
     for i in 1:length(z)
         zi = z[i]
-        b̄ += (cbrt(b[i,i])*invn2*zi^2)^3
-        for j in 1:(i-1)
-            b̄ += 2*(cbrt(b[i,j])*invn2*zi*z[j])^3
-        end
-    end
-
-    ā = zero(eltype(α))+zero(eltype(z))
-    for i in 1:length(z)
-        zi = z[i]
+        zi2 = zi*zi
         αi = α[i]
-        ā += a[i,i]*αi/b[i,i]*zi*b̄
+        b̄ += cbrt(b[i,i])*zi2
+        abij2 = (a[i,i]*αi/b[i,i])^2
+        ab2 += abij2*zi2
         for j in 1:(i-1)
-            ā += 2*sqrt(zi*z[j]*invn2*(a[i,j]*sqrt(αi*α[j])/b[i,j])^2)*b̄
+            zij =zi*z[j]
+            abij2 = (a[i,j]*sqrt(αi*α[j])/b[i,j])^2
+            ab2 += 2*abij2*zij
+            b̄ += 2*cbrt(b[i,j])*zij
         end
-    end
-    ā
+    end    
+    b̄ = (b̄*invn2)^3
+    ā = sqrt(ab2*invn2)*b̄
+    c̄ = dot(z,c)*invn
     return ā,b̄,c̄
 end
 

--- a/src/models/eos/cubic/mixing/LCVM.jl
+++ b/src/models/eos/cubic/mixing/LCVM.jl
@@ -9,7 +9,6 @@ end
 export LCVMRule
 function LCVMRule(components::Vector{String}; activity = Wilson, userlocations::Vector{String}=String[],activity_userlocations::Vector{String}=String[], verbose::Bool=false)
     init_activity = activity(components;userlocations = activity_userlocations,verbose)
-    
     model = LCVMRule(components, init_activity)
     return model
 end
@@ -24,7 +23,7 @@ function mixing_rule(model::PRModel,V,T,z,mixing_model::LCVMRuleModel,α,a,b,c)
     b̄ = dot(z,Symmetric(b),z) * invn2
     c̄ = dot(z,c)/n
     #ᾱ  = a.*sqrt.(α.*α')./(b*R̄*T)
-    Σxᾱ  = sum(α[i]*a[i,i]*z[i]/b[i] for i ∈ @comps)*invn
+    Σxᾱ  = sum(α[i]*a[i,i]*z[i]/b[i,i] for i ∈ @comps)*invn/(R̄*T)
     λ  = 0.7
     AV = -0.52
     AM = -0.623

--- a/src/models/eos/cubic/mixing/LCVM.jl
+++ b/src/models/eos/cubic/mixing/LCVM.jl
@@ -17,19 +17,19 @@ end
 
 function mixing_rule(model::PRModel,V,T,z,mixing_model::LCVMRuleModel,α,a,b,c)
     n = sum(z)
-    x = z./n
-    invn2 = (one(n)/n)^2
+    #x = z./n
+    invn = (one(n)/n)
+    invn2 = invn^2
     g_E = excess_gibbs_free_energy(mixing_model.activity,1e5,T,z) / n
     b̄ = dot(z,Symmetric(b),z) * invn2
     c̄ = dot(z,c)/n
-
-    ᾱ = a.*sqrt.(α.*α')./(b*R̄*T)
-
+    #ᾱ  = a.*sqrt.(α.*α')./(b*R̄*T)
+    Σxᾱ  = sum(α[i]*a[i,i]*z[i]/b[i] for i ∈ @comps)*invn
     λ  = 0.7
     AV = -0.52
     AM = -0.623
-    C1 = λ/AV+(1-λ)/AM
-
-    ā = b̄*R̄*T*(C1*(g_E/(R̄*T)-0.3*sum(x[i]*log(b̄/b[i,i]) for i ∈ @comps))+sum(x[i]*ᾱ[i,i] for i ∈ @comps))
+    C1 = -1.8276947771329795 #λ/AV+(1-λ)/AM,is this ok?, that C1 is independent of the input conditions
+    Σlogb = sum(z[i]*log(b̄/b[i,i]) for i ∈ @comps)*invn #sum(x[i]*log(b̄/b[i,i]) for i ∈ @comps)
+    ā = b̄*R̄*T*(C1*(g_E/(R̄*T)-0.3*Σlogb)+Σxᾱ )
     return ā,b̄,c̄
 end

--- a/src/models/eos/cubic/mixing/MHV2.jl
+++ b/src/models/eos/cubic/mixing/MHV2.jl
@@ -14,24 +14,26 @@ function MHV2Rule(components::Vector{String}; activity = Wilson, userlocations::
     return model
 end
 
-function mixing_rule(model::RKModel,V,T,z,mixing_model::MHV2RuleModel,α,a,b,c)
+MHV2q(::PRModel) = (-0.4347,-0.003654)
+MHV2q(::RKModel) = (-0.4783,-0.0047 )
+function mixing_rule(model::Union{PRModel,RKModel},V,T,z,mixing_model::MHV2RuleModel,α,a,b,c)
     n = sum(z)
-    x = z./n
-    invn2 = (one(n)/n)^2
+    #x = z./n
+    invn = (one(n)/n)
+    invn2 = invn^2
     g_E = excess_gibbs_free_energy(mixing_model.activity,1e5,T,z) / n
     b̄ = dot(z,Symmetric(b),z) * invn2
     c̄ = dot(z,c)/n
-
-    ᾱ = a.*sqrt.(α.*α')./(b*R̄*T)
-
-    q1 = -0.4783
-    q2 = -0.0047
-    c  = -q1*sum(x[i]*ᾱ[i,i] for i ∈ @comps)-q2*sum(x[i]*ᾱ[i,i]^2 for i ∈ @comps)-g_E/(R̄*T)-sum(x[i]*log(b̄/b[i,i]) for i ∈ @comps)
-
+    #ᾱ = a.*sqrt.(α.*α')./(b*R̄*T)
+    q1,q2 = MHV2q(model)
+    Σlogb = sum(z[i]*log(b̄/b[i,i]) for i ∈ @comps)
+    Σab = sum(z[i]*a[i,i]*α[i]/b[i,i]/(R̄*T) for i ∈ @comps)*invn
+    Σab2 = sum(z[i]*a[i,i]*(α[i]^2)/b[i,i]/(R̄*T) for i ∈ @comps)*invn
+    c  = -q1*Σab-q2*Σab2-g_E/(R̄*T)-Σlogb
     ā = b̄*R̄*T*(-q1-sqrt(q1^2-4*q2*c))/(2*q2)
     return ā,b̄,c̄
 end
-
+#=
 function mixing_rule(model::PRModel,V,T,z,mixing_model::MHV2RuleModel,α,a,b,c)
     n = sum(z)
     x = z./n
@@ -48,4 +50,4 @@ function mixing_rule(model::PRModel,V,T,z,mixing_model::MHV2RuleModel,α,a,b,c)
 
     ā = b̄*R̄*T*(-q1-sqrt(q1^2-4*q2*c))/(2*q2)
     return ā,b̄,c̄
-end
+end=#

--- a/src/models/eos/cubic/mixing/PSRK.jl
+++ b/src/models/eos/cubic/mixing/PSRK.jl
@@ -16,11 +16,13 @@ end
 
 function mixing_rule(model::RKModel,V,T,z,mixing_model::PSRKRuleModel,α,a,b,c)
     n = sum(z)
-    x = z./n
-    invn2 = (one(n)/n)^2
+    invn = (one(n)/n)
+    invn2 = invn^2
     g_E = excess_gibbs_free_energy(mixing_model.activity,1e5,T,z) / n
     b̄ = dot(z,Symmetric(b),z) * invn2
     c̄ = dot(z,c)/n
-    ā = b̄*R̄*T*(sum(x[i]*a[i,i]*α[i]/b[i,i]/(R̄*T) for i ∈ @comps)-1/0.64663*(g_E/(R̄*T)+sum(x[i]*log(b̄/b[i,i]) for i ∈ @comps)))
+    Σlogb = sum(z[i]*log(b̄/b[i,i]) for i ∈ @comps)*invn
+    Σab = sum(z[i]*a[i,i]*α[i]/b[i,i]/(R̄*T) for i ∈ @comps)*invn
+    ā = b̄*R̄*T*(Σab-1/0.64663*(g_E/(R̄*T)+Σlogb))
     return ā,b̄,c̄
 end

--- a/src/models/eos/cubic/mixing/UMR.jl
+++ b/src/models/eos/cubic/mixing/UMR.jl
@@ -8,23 +8,35 @@ end
 @registermodel UMRRule
 export UMRRule
 function UMRRule(components::Vector{String}; activity = Wilson, userlocations::Vector{String}=String[],activity_userlocations::Vector{String}=String[], verbose::Bool=false)
-    init_activity = activity(components;userlocations = activity_userlocations,verbose)
-    
+    init_activity = activity(components;userlocations = activity_userlocations,verbose)   
     model = UMRRule(components, init_activity)
     return model
 end
 
+function ab_premixing(::Type{PR},mixing::UMRRuleModel,Tc,pc,kij)
+    Ωa, Ωb = ab_consts(PR)
+    _Tc = Tc.values
+    _pc = pc.values
+    a = epsilon_LorentzBerthelot(SingleParam(pc, @. Ωa*R̄^2*_Tc^2/_pc),kij)
+    bi = @. Ωb*R̄*_Tc/_pc
+    bij = ((b.^(1/2).+b'.^(1/2))/2).^2
+    b = PairParam("b",_Tc.components,bij)
+    return a,b
+end
+
 function mixing_rule(model::PRModel,V,T,z,mixing_model::UMRRuleModel,α,a,b,c)
     n = sum(z)
-    x = z./n
-    invn2 = (one(n)/n)^2
+    #x = z./n
+    invn = (one(n)/n)
+    invn2 = invn^2
     lnγ_SG_  = lnγ_SG(mixing_model.activity,1e5,T,z)
     lnγ_res_ = lnγ_res(mixing_model.activity,1e5,T,z)
-    g_E = sum(x[i]*R̄*T*(lnγ_res_[i]+lnγ_SG_[i]) for i ∈ @comps)
-    b = Diagonal(b).diag
-    b = ((b.^(1/2).+b'.^(1/2))/2).^2
+    g_E = sum(z[i]*R̄*T*(lnγ_res_[i]+lnγ_SG_[i]) for i ∈ @comps)*invn
+    #b = Diagonal(b).diag
+    #b = ((b.^(1/2).+b'.^(1/2))/2).^2
     b̄ = dot(z,Symmetric(b),z) * invn2
-    c̄ = dot(z,c)/n
-    ā = b̄*R̄*T*(sum(x[i]*a[i,i]*α[i]/b[i,i]/(R̄*T) for i ∈ @comps)-1/0.53*g_E/(R̄*T))
+    c̄ = dot(z,c)*invn
+    Σab = sum(z[i]*a[i,i]*α[i]/b[i,i]/(R̄*T) for i ∈ @comps)*invn
+    ā = b̄*R̄*T*(Σab-1/0.53*g_E/(R̄*T))
     return ā,b̄,c̄
 end

--- a/src/models/eos/cubic/mixing/UMR.jl
+++ b/src/models/eos/cubic/mixing/UMR.jl
@@ -19,7 +19,7 @@ function ab_premixing(::Type{PR},mixing::UMRRuleModel,Tc,pc,kij)
     _pc = pc.values
     a = epsilon_LorentzBerthelot(SingleParam(pc, @. Ωa*R̄^2*_Tc^2/_pc),kij)
     bi = @. Ωb*R̄*_Tc/_pc
-    bij = ((b.^(1/2).+b'.^(1/2))/2).^2
+    bij = ((bi.^(1/2).+bi'.^(1/2))/2).^2
     b = PairParam("b",_Tc.components,bij)
     return a,b
 end

--- a/src/models/eos/cubic/mixing/UMR.jl
+++ b/src/models/eos/cubic/mixing/UMR.jl
@@ -20,7 +20,7 @@ function ab_premixing(::Type{PR},mixing::UMRRuleModel,Tc,pc,kij)
     a = epsilon_LorentzBerthelot(SingleParam(pc, @. Ωa*R̄^2*_Tc^2/_pc),kij)
     bi = @. Ωb*R̄*_Tc/_pc
     bij = ((bi.^(1/2).+bi'.^(1/2))/2).^2
-    b = PairParam("b",_Tc.components,bij)
+    b = PairParam("b",Tc.components,bij)
     return a,b
 end
 

--- a/src/models/eos/cubic/mixing/VTPR.jl
+++ b/src/models/eos/cubic/mixing/VTPR.jl
@@ -14,16 +14,29 @@ function VTPRRule(components::Vector{String}; activity = Wilson, userlocations::
     return model
 end
 
+function ab_premixing(::Type{PR},mixing::UMRRuleModel,Tc,pc,kij)
+    Ωa, Ωb = ab_consts(PR)
+    _Tc = Tc.values
+    _pc = pc.values
+    a = epsilon_LorentzBerthelot(SingleParam(pc, @. Ωa*R̄^2*_Tc^2/_pc),kij)
+    bi = @. Ωb*R̄*_Tc/_pc
+    bij = ((b.^(3/4).+b'.^(3/4))/2).^(4/3)
+    b = PairParam("b",_Tc.components,bij)
+    return a,b
+end
+
 function mixing_rule(model::PRModel,V,T,z,mixing_model::VTPRRuleModel,α,a,b,c)
     n = sum(z)
-    x = z./n
-    invn2 = (one(n)/n)^2
+    #x = z./n
+    invn = (one(n)/n)
+    invn2 = invn^2
     lnγ_res_ = lnγ_res(mixing_model.activity,1e5,T,z)
     g_E_res = sum(x[i]*R̄*T*lnγ_res_[i] for i ∈ @comps)
-    b = Diagonal(b).diag
-    b = ((b.^(3/4).+b'.^(3/4))/2).^(4/3)
+    #b = Diagonal(b).diag
+    #b = ((b.^(3/4).+b'.^(3/4))/2).^(4/3)
     b̄ = dot(z,Symmetric(b),z) * invn2
     c̄ = dot(z,c)/n
-    ā = b̄*R̄*T*(sum(x[i]*a[i,i]*α[i]/b[i,i]/(R̄*T) for i ∈ @comps)-1/0.53087*(g_E_res/(R̄*T)))
+    Σab = invn*sum(z[i]*a[i,i]*α[i]/b[i,i]/(R̄*T) for i ∈ @comps)
+    ā = b̄*R̄*T*(Σab-1/0.53087*(g_E_res/(R̄*T)))
     return ā,b̄,c̄
 end

--- a/src/models/eos/cubic/mixing/VTPR.jl
+++ b/src/models/eos/cubic/mixing/VTPR.jl
@@ -20,7 +20,7 @@ function ab_premixing(::Type{PR},mixing::VTPRRule,Tc,pc,kij)
     _pc = pc.values
     a = epsilon_LorentzBerthelot(SingleParam(pc, @. Ωa*R̄^2*_Tc^2/_pc),kij)
     bi = @. Ωb*R̄*_Tc/_pc
-    bij = ((b.^(3/4).+b'.^(3/4))/2).^(4/3)
+    bij = ((bi.^(3/4).+bi'.^(3/4))/2).^(4/3)
     b = PairParam("b",_Tc.components,bij)
     return a,b
 end

--- a/src/models/eos/cubic/mixing/VTPR.jl
+++ b/src/models/eos/cubic/mixing/VTPR.jl
@@ -21,19 +21,16 @@ function ab_premixing(::Type{PR},mixing::VTPRRule,Tc,pc,kij)
     a = epsilon_LorentzBerthelot(SingleParam(pc, @. Ωa*R̄^2*_Tc^2/_pc),kij)
     bi = @. Ωb*R̄*_Tc/_pc
     bij = ((bi.^(3/4).+bi'.^(3/4))/2).^(4/3)
-    b = PairParam("b",_Tc.components,bij)
+    b = PairParam("b",Tc.components,bij)
     return a,b
 end
 
 function mixing_rule(model::PRModel,V,T,z,mixing_model::VTPRRuleModel,α,a,b,c)
     n = sum(z)
-    #x = z./n
     invn = (one(n)/n)
     invn2 = invn^2
     lnγ_res_ = lnγ_res(mixing_model.activity,1e5,T,z)
-    g_E_res = sum(x[i]*R̄*T*lnγ_res_[i] for i ∈ @comps)
-    #b = Diagonal(b).diag
-    #b = ((b.^(3/4).+b'.^(3/4))/2).^(4/3)
+    g_E_res = sum(z[i]*R̄*T*lnγ_res_[i] for i ∈ @comps)*invn
     b̄ = dot(z,Symmetric(b),z) * invn2
     c̄ = dot(z,c)/n
     Σab = invn*sum(z[i]*a[i,i]*α[i]/b[i,i]/(R̄*T) for i ∈ @comps)

--- a/src/models/eos/cubic/mixing/VTPR.jl
+++ b/src/models/eos/cubic/mixing/VTPR.jl
@@ -14,7 +14,7 @@ function VTPRRule(components::Vector{String}; activity = Wilson, userlocations::
     return model
 end
 
-function ab_premixing(::Type{PR},mixing::UMRRuleModel,Tc,pc,kij)
+function ab_premixing(::Type{PR},mixing::VTPRRule,Tc,pc,kij)
     Ωa, Ωb = ab_consts(PR)
     _Tc = Tc.values
     _pc = pc.values

--- a/src/models/eos/cubic/mixing/WS.jl
+++ b/src/models/eos/cubic/mixing/WS.jl
@@ -15,16 +15,17 @@ function WSRule(components::Vector{String}; activity = Wilson, userlocations::Ve
 end
 
 WS_λ(::PRModel) = 0.6232252401402305 #1/(2*√(2))*log((2+√(2))/(2-√(2)))
-WS_λ(::RKModel) = 0.6931471805599453 #log(2)
+WS_λ(::RKModel) = 0.6931471805599453#log(2)
 
 function mixing_rule(model::Union{RKModel,PRModel},V,T,z,mixing_model::WSRuleModel,α,a,b,c)
     λ = WS_λ(model)
     n = sum(z)
     invn = (one(n)/n)
-    Σab = sum(z[i]*a[i,i]*α[i]/b[i,i]/(R̄*T) for i ∈ @comps)*invn
-    num = Σab
-    den = 1 - (Σab-excess_gibbs_free_energy(mixing_model.activity,1e5,T,z)/(n*R̄*T)/λ)
-    c̄ = dot(z,c)/n
+    Σab = sum(z[i]*a[i,i]*α[i]/b[i,i]/(n*R̄*T) for i ∈ @comps)
+    num = sum(z[i]*(b[i,i]-a[i,i]*α[i]/(R̄*T)) for i ∈ @comps)*invn
+    gE = excess_gibbs_free_energy(mixing_model.activity,1e5,T,z)
+    den = 1 - (Σab-gE/(n*R̄*T)/λ)
+    c̄ = dot(z,c)*invn
     b̄  = num/den
     ā  = R̄*T*(b̄-num)
     return ā,b̄,c̄

--- a/src/models/eos/cubic/mixing/WS.jl
+++ b/src/models/eos/cubic/mixing/WS.jl
@@ -14,23 +14,17 @@ function WSRule(components::Vector{String}; activity = Wilson, userlocations::Ve
     return model
 end
 
-function mixing_rule(model::RKModel,V,T,z,mixing_model::WSRuleModel,α,a,b,c)
-    n = sum(z)
-    invn2 = (one(n)/n)^2
-    num = sum(z[i]*(b[i,i]-a[i,i]*α[i]/(R̄*T)) for i ∈ @comps)/n
-    den = 1 - (sum(z[i]*a[i,i]*α[i]/b[i,i]/(n*R̄*T) for i ∈ @comps)-excess_gibbs_free_energy(mixing_model.activity,1e5,T,z)/(n*R̄*T)/log(2))
-    c̄ = dot(z,c)/n
-    b̄  = num/den
-    ā  = R̄*T*(b̄-num)
-    return ā,b̄,c̄
-end
+WS_λ(::PRModel) = 1/(2*√(2))*log((2+√(2))/(2-√(2))) #definitely check this
+WS_λ(::RKModel) = log(2)
 
-function mixing_rule(model::PRModel,V,T,z,mixing_model::WSRuleModel,α,a,b,c)
-    λ = 1/(2*√(2))*log((2+√(2))/(2-√(2)))
+function mixing_rule(model::Union{RKModel,PRModel},V,T,z,mixing_model::WSRuleModel,α,a,b,c)
+    λ = WS_λ(model)
     n = sum(z)
-    invn2 = (one(n)/n)^2
-    num = sum(z[i]*(b[i,i]-a[i,i]*α[i]/(R̄*T)) for i ∈ @comps)/n
-    den = 1 - (sum(z[i]*a[i,i]*α[i]/b[i,i]/(n*R̄*T) for i ∈ @comps)-excess_gibbs_free_energy(mixing_model.activity,1e5,T,z)/(n*R̄*T)/λ)
+    invn = (one(n)/n)
+    invn2 = invn^2
+    Σab = sum(z[i]*a[i,i]*α[i]/b[i,i]/(R̄*T) for i ∈ @comps)*invn
+    num = Σab
+    den = 1 - (Σab-excess_gibbs_free_energy(mixing_model.activity,1e5,T,z)/(n*R̄*T)/λ)
     c̄ = dot(z,c)/n
     b̄  = num/den
     ā  = R̄*T*(b̄-num)

--- a/src/models/eos/cubic/mixing/WS.jl
+++ b/src/models/eos/cubic/mixing/WS.jl
@@ -14,14 +14,13 @@ function WSRule(components::Vector{String}; activity = Wilson, userlocations::Ve
     return model
 end
 
-WS_λ(::PRModel) = 1/(2*√(2))*log((2+√(2))/(2-√(2))) #definitely check this
-WS_λ(::RKModel) = log(2)
+WS_λ(::PRModel) = 0.6232252401402305 #1/(2*√(2))*log((2+√(2))/(2-√(2)))
+WS_λ(::RKModel) = 0.6931471805599453 #log(2)
 
 function mixing_rule(model::Union{RKModel,PRModel},V,T,z,mixing_model::WSRuleModel,α,a,b,c)
     λ = WS_λ(model)
     n = sum(z)
     invn = (one(n)/n)
-    invn2 = invn^2
     Σab = sum(z[i]*a[i,i]*α[i]/b[i,i]/(R̄*T) for i ∈ @comps)*invn
     num = Σab
     den = 1 - (Σab-excess_gibbs_free_energy(mixing_model.activity,1e5,T,z)/(n*R̄*T)/λ)

--- a/src/models/eos/cubic/mixing/vdW1f.jl
+++ b/src/models/eos/cubic/mixing/vdW1f.jl
@@ -16,19 +16,26 @@ end
 
 function mixing_rule(model::ABCubicModel,V,T,z,mixing_model::vdW1fRuleModel,α,a,b,c)
     n = sum(z)
-    invn2 = (one(n)/n)^2
-    b̄ = dot(z,Symmetric(b),z) * invn2
-    c̄ = dot(z,c)/n
-    ā = zero(eltype(α))+zero(eltype(z))
+    invn = (one(n)/n)
+    invn2 = invn^2
+    #b̄ = dot(z,Symmetric(b),z) * invn2
+    ā = zero(T+first(z))
+    b̄ = zero(first(z))
     for i in 1:length(z)
         zi = z[i]
         αi = α[i]
-        ā+= a[i,i]*αi*zi^2
+        zi2 = zi^2
+        b̄ += b[i,i]*zi2
+        ā += a[i,i]*αi*zi^2
         for j in 1:(i-1)
-            ā+= 2*a[i,j]*sqrt(αi*α[j])*zi*z[j]
+            zij = zi*z[j]
+            ā += 2*a[i,j]*sqrt(αi*α[j])*zij
+            b̄ += 2*b[i,j]*zij
         end
     end
     ā *= invn2
+    b̄ *= invn2
+    c̄ = dot(z,c)*invn
     #dot(z,Symmetric(a .* sqrt.(α*α')),z) * invn2
     return ā,b̄,c̄
 end

--- a/src/models/eos/cubic/mixing/vdW1f.jl
+++ b/src/models/eos/cubic/mixing/vdW1f.jl
@@ -19,8 +19,20 @@ function mixing_rule(model::ABCubicModel,V,T,z,mixing_model::vdW1fRuleModel,α,a
     invn2 = (one(n)/n)^2
     b̄ = dot(z,Symmetric(b),z) * invn2
     c̄ = dot(z,c)/n
-    ā = dot(z,Symmetric(a .* sqrt.(α*α')),z) * invn2
+    ā = zero(eltype(α))+zero(eltype(z))
+    for i in 1:length(z)
+        zi = z[i]
+        αi = α[i]
+        ā+= a[i,i]*αi*zi^2
+        for j in 1:(i-1)
+            ā+= 2*a[i,j]*sqrt(αi*α[j])*zi*z[j]
+        end
+    end
+    ā *= invn2
+    #dot(z,Symmetric(a .* sqrt.(α*α')),z) * invn2
     return ā,b̄,c̄
 end
+
+
 
 is_splittable(::vdW1fRule) = false

--- a/src/models/eos/cubic/translation/MT.jl
+++ b/src/models/eos/cubic/translation/MT.jl
@@ -19,13 +19,10 @@ function translation(model::CubicModel,V,T,z,translation_model::MTTranslation)
     Tc = model.params.Tc.values
     Pc = model.params.Pc.values
     ω  = translation_model.params.acentricfactor.values
-
     Zc = @. 0.289-0.0701*ω-0.0207*ω^2
     β  = @. -10.2447-28.6312*ω
-
     t0 = @. R̄*Tc/Pc*(-0.014471+0.067498*ω-0.084852*ω^2+0.067298*ω^3-0.017366*ω^4)
     tc = @. R̄*Tc/Pc*(0.3074-Zc)
-
     Tr = @. T/Tc
     return @. t0+(tc-t0)*exp(β*abs(1-Tr))
 end

--- a/src/models/eos/cubic/vdW.jl
+++ b/src/models/eos/cubic/vdW.jl
@@ -35,21 +35,15 @@ function vdW(components::Vector{String}; idealmodel=BasicIdeal,
      verbose=false)
     params = getparams(components, ["properties/critical.csv", "properties/molarmass.csv","SAFT/PCSAFT/PCSAFT_unlike.csv"]; userlocations=userlocations, verbose=verbose)
     k  = params["k"]
-    _pc = params["pc"]
-    pc = _pc.values
+    pc = params["pc"]
     Mw = params["Mw"]
-    _Tc = params["Tc"]
-    Tc = _Tc.values
-    #T̄c = sum(sqrt.(Tc*Tc')) #is this term correctly calculated? sqrt(Tc*Tc') is a matrix sqrt
-    a = epsilon_LorentzBerthelot(SingleParam(params["pc"], @. 27/64*R̄^2*Tc^2/pc), k)
-    b = sigma_LorentzBerthelot(SingleParam(params["pc"], @. 1/8*R̄*Tc/pc))
-    
-    init_idealmodel = init_model(idealmodel,components,ideal_userlocations,verbose)
+    Tc = params["Tc"]
     init_mixing = init_model(mixing,components,activity,mixing_userlocations,activity_userlocations,verbose)
+    a,b = ab_premixing(vdW,init_mixing,Tc,pc,k)
+    init_idealmodel = init_model(idealmodel,components,ideal_userlocations,verbose)
     init_translation = init_model(translation,components,translation_userlocations,verbose)
-
     icomponents = 1:length(components)
-    packagedparams = vdWParam(a, b, params["Tc"],_pc,Mw)
+    packagedparams = vdWParam(a,b,Tc,pc,Mw)
     references = String[]
     model = vdW(components,icomponents,init_mixing,init_translation,packagedparams,init_idealmodel,1e-12,references)
     return model


### PR DESCRIPTION
the cubic rewrite gave us unseen flexibility, but we lost some speed in the progress. this pr aims to get some of that speed back. 
- allocations are eliminated on VdWf1 and Kay and all mixing that does not require an activity. calling activity methods incurs in allocations, but that is another front of optimization.
- for VTPR and UMRPR, there are some custom "pre" mixing rules for `b`, that is, they use a diferent bij that the returned by lorentz-bertelot. to acomodate this, a new function `ab_premixing(Type{Model},mixing,Tc,pc,k)`, so we can dispatch on. that function is now used by VdW, PR, and RK models