### PR TITLE
Assoc options

### DIFF
--- a/src/Clapeyron.jl
+++ b/src/Clapeyron.jl
@@ -15,7 +15,7 @@ using DiffResults, ForwardDiff
 using Scratch 
 include("solvers/Solvers.jl")
 using .Solvers
-using .Solvers: log
+using .Solvers: log, sqrt
 using Unitful
 import LogExpFunctions
 include("constants.jl")

--- a/src/models/eos/SAFT/BACKSAFT/BACKSAFT.jl
+++ b/src/models/eos/SAFT/BACKSAFT/BACKSAFT.jl
@@ -10,7 +10,13 @@ abstract type BACKSAFTModel <: SAFTModel end
 @newmodel BACKSAFT BACKSAFTModel BACKSAFTParam
 
 export BACKSAFT
-function BACKSAFT(components; idealmodel=BasicIdeal, userlocations=String[], ideal_userlocations=String[], verbose=false)
+function BACKSAFT(components; 
+    idealmodel=BasicIdeal,
+    userlocations=String[],
+    ideal_userlocations=String[],
+    verbose=false,
+    assoc_options = AssocOptions())
+
     params = getparams(components, ["SAFT/BACKSAFT","properties/molarmass.csv"]; userlocations=userlocations, verbose=verbose)
     segment = params["m"]
     c = params["c"]
@@ -24,7 +30,7 @@ function BACKSAFT(components; idealmodel=BasicIdeal, userlocations=String[], ide
     packagedparams = BACKSAFTParam(segment, sigma, epsilon, c, alpha)
     references = ["TODO BACKSAFT", "TODO BACKSAFT"]
 
-    model = BACKSAFT(packagedparams, idealmodel; ideal_userlocations=ideal_userlocations, references=references, verbose=verbose)
+    model = BACKSAFT(packagedparams, idealmodel; ideal_userlocations, references, verbose, assoc_options)
     return model
 end
 

--- a/src/models/eos/SAFT/CKSAFT/CKSAFT.jl
+++ b/src/models/eos/SAFT/CKSAFT/CKSAFT.jl
@@ -11,7 +11,13 @@ abstract type CKSAFTModel <: SAFTModel end
 @newmodel CKSAFT CKSAFTModel CKSAFTParam
 
 export CKSAFT
-function CKSAFT(components; idealmodel=BasicIdeal, userlocations=String[], ideal_userlocations=String[], verbose=false)
+function CKSAFT(components;
+    idealmodel=BasicIdeal,
+    userlocations=String[],
+    ideal_userlocations=String[],
+    verbose=false,
+    assoc_options = AssocOptions())
+
     params,sites = getparams(components, ["SAFT/CKSAFT","properties/molarmass.csv"]; userlocations=userlocations, verbose=verbose)
     segment = params["m"]
     c = params["c"]
@@ -26,7 +32,7 @@ function CKSAFT(components; idealmodel=BasicIdeal, userlocations=String[], ideal
     packagedparams = CKSAFTParam(segment, sigma, epsilon,c, epsilon_assoc, bondvol)
     references = ["TODO CKSAFT", "TODO CKSAFT"]
 
-    model = CKSAFT(packagedparams, sites, idealmodel; ideal_userlocations=ideal_userlocations, references=references, verbose=verbose)
+    model = CKSAFT(packagedparams, sites, idealmodel; ideal_userlocations, references, verbose, assoc_options)
     return model
 end
 

--- a/src/models/eos/SAFT/CKSAFT/variants/sCKSAFT.jl
+++ b/src/models/eos/SAFT/CKSAFT/variants/sCKSAFT.jl
@@ -9,7 +9,13 @@ end
 abstract type sCKSAFTModel <: CKSAFTModel end
 @newmodel sCKSAFT sCKSAFTModel sCKSAFTParam
 export sCKSAFT
-function sCKSAFT(components; idealmodel=BasicIdeal, userlocations=String[], ideal_userlocations=String[], verbose=false)
+function sCKSAFT(components;
+    idealmodel=BasicIdeal,
+    userlocations=String[],
+    ideal_userlocations=String[],
+    verbose=false,
+    assoc_options = AssocOptions())
+
     params,sites = getparams(components, ["SAFT/sCKSAFT","properties/molarmass.csv"]; userlocations=userlocations, verbose=verbose)
     segment = params["m"]
     k = params["k"]
@@ -24,7 +30,7 @@ function sCKSAFT(components; idealmodel=BasicIdeal, userlocations=String[], idea
     packagedparams = sCKSAFTParam(segment, sigma, epsilon, epsilon_assoc, bondvol)
     references = ["TODO sCKSAFT", "TODO sCKSAFT"]
 
-    model = sCKSAFT(packagedparams, sites, idealmodel; ideal_userlocations=ideal_userlocations, references=references, verbose=verbose)
+    model = sCKSAFT(packagedparams, sites, idealmodel; ideal_userlocations, references, verbose, assoc_options)
     return model
 end
 

--- a/src/models/eos/SAFT/CPA/CPA.jl
+++ b/src/models/eos/SAFT/CPA/CPA.jl
@@ -12,7 +12,12 @@ abstract type CPAModel <: EoSModel end
 @newmodel CPA CPAModel CPAParam
 
 export CPA
-function CPA(components; idealmodel=BasicIdeal, userlocations=String[], ideal_userlocations=String[], verbose=false)
+function CPA(components;
+    idealmodel=BasicIdeal,
+    userlocations=String[],
+    ideal_userlocations=String[],
+    verbose=false,
+    assoc_options = AssocOptions())
     params,sites = getparams(components, ["SAFT/CPA", "properties/molarmass.csv","properties/critical.csv"]; userlocations=userlocations, verbose=verbose)
     Mw  = params["Mw"]
     k  = params["k"]
@@ -27,7 +32,7 @@ function CPA(components; idealmodel=BasicIdeal, userlocations=String[], ideal_us
     packagedparams = CPAParam(a, b, c1, Tc, epsilon_assoc, bondvol,Mw)
     references = ["10.1021/ie051305v"]
 
-    model = CPA(packagedparams, sites, idealmodel; ideal_userlocations=ideal_userlocations, references=references, verbose=verbose)
+    model = CPA(packagedparams, sites, idealmodel; ideal_userlocations, references, verbose, assoc_options)
     return model
 end
 

--- a/src/models/eos/SAFT/LJSAFT/LJSAFT.jl
+++ b/src/models/eos/SAFT/LJSAFT/LJSAFT.jl
@@ -10,7 +10,12 @@ abstract type LJSAFTModel <: SAFTModel end
 @newmodel LJSAFT LJSAFTModel LJSAFTParam
 
 export LJSAFT
-function LJSAFT(components; idealmodel=BasicIdeal, userlocations=String[], ideal_userlocations=String[], verbose=false)
+function LJSAFT(components;
+    idealmodel=BasicIdeal,
+    userlocations=String[],
+    ideal_userlocations=String[],
+    verbose=false,
+    assoc_options = AssocOptions())
     params,sites = getparams(components, ["SAFT/LJSAFT"]; userlocations=userlocations, verbose=verbose)
     segment = params["m"]
 
@@ -28,7 +33,7 @@ function LJSAFT(components; idealmodel=BasicIdeal, userlocations=String[], ideal
     packagedparams = LJSAFTParam(segment, b, T_tilde, epsilon_assoc, bondvol)
     references = ["10.1021/ie9602320"]
 
-    model = LJSAFT(packagedparams, sites, idealmodel; ideal_userlocations=ideal_userlocations, references=references, verbose=verbose)
+    model = LJSAFT(packagedparams, sites, idealmodel; ideal_userlocations, references, verbose, assoc_options)
     return model
 end
 

--- a/src/models/eos/SAFT/PCSAFT/PCSAFT.jl
+++ b/src/models/eos/SAFT/PCSAFT/PCSAFT.jl
@@ -11,7 +11,12 @@ abstract type PCSAFTModel <: SAFTModel end
 @newmodel PCSAFT PCSAFTModel PCSAFTParam
 
 export PCSAFT
-function PCSAFT(components; idealmodel=BasicIdeal, userlocations=String[], ideal_userlocations=String[], verbose=false)
+function PCSAFT(components;
+    idealmodel=BasicIdeal,
+    userlocations=String[],
+    ideal_userlocations=String[],
+    verbose=false,
+    assoc_options = AssocOptions())
     params,sites = getparams(components, ["SAFT/PCSAFT","properties/molarmass.csv"]; userlocations=userlocations, verbose=verbose)
     
     segment = params["m"]
@@ -26,7 +31,7 @@ function PCSAFT(components; idealmodel=BasicIdeal, userlocations=String[], ideal
     packagedparams = PCSAFTParam(Mw, segment, sigma, epsilon, epsilon_assoc, bondvol)
     references = ["10.1021/ie0003887", "10.1021/ie010954d"]
 
-    model = PCSAFT(packagedparams, sites, idealmodel; ideal_userlocations=ideal_userlocations, references=references, verbose=verbose)
+    model = PCSAFT(packagedparams, sites, idealmodel; ideal_userlocations, references, verbose, assoc_options)
     return model
 end
 

--- a/src/models/eos/SAFT/PCSAFT/variants/sPCSAFT.jl
+++ b/src/models/eos/SAFT/PCSAFT/variants/sPCSAFT.jl
@@ -2,7 +2,13 @@ abstract type sPCSAFTModel <: PCSAFTModel end
 @newmodel sPCSAFT sPCSAFTModel PCSAFTParam
 
 export sPCSAFT
-function sPCSAFT(components; idealmodel=BasicIdeal, userlocations=String[], ideal_userlocations=String[], verbose=false)
+function sPCSAFT(components;
+    idealmodel=BasicIdeal,
+    userlocations=String[],
+    ideal_userlocations=String[],
+    verbose=false,
+    assoc_options = AssocOptions())
+    
     params,sites = getparams(components, ["SAFT/PCSAFT", "SAFT/PCSAFT/sPCSAFT"]; userlocations=userlocations, verbose=verbose)
     
     segment = params["m"]
@@ -16,7 +22,7 @@ function sPCSAFT(components; idealmodel=BasicIdeal, userlocations=String[], idea
     packagedparams = PCSAFTParam(Mw, segment, sigma, epsilon, epsilon_assoc, bondvol)
     references = ["10.1021/ie020753p"]
 
-    model = sPCSAFT(packagedparams, sites, idealmodel; ideal_userlocations=ideal_userlocations, references=references, verbose=verbose)
+    model = sPCSAFT(packagedparams, sites, idealmodel; ideal_userlocations, references, verbose, assoc_options)
     return model
 end
 

--- a/src/models/eos/SAFT/SAFTVRMie/SAFTVRMie.jl
+++ b/src/models/eos/SAFT/SAFTVRMie/SAFTVRMie.jl
@@ -13,7 +13,12 @@ abstract type SAFTVRMieModel <: SAFTModel end
 @newmodel SAFTVRMie SAFTVRMieModel SAFTVRMieParam
 
 export SAFTVRMie
-function SAFTVRMie(components; idealmodel=BasicIdeal, userlocations=String[], ideal_userlocations=String[], verbose=false)
+function SAFTVRMie(components;
+    idealmodel=BasicIdeal,
+    userlocations=String[],
+    ideal_userlocations=String[],
+    verbose=false,
+    assoc_options = AssocOptions())
     params,sites = getparams(components, ["SAFT/SAFTVRMie", "properties/molarmass.csv"]; userlocations=userlocations, verbose=verbose)
 
     params["Mw"].values .*= 1E-3
@@ -30,7 +35,7 @@ function SAFTVRMie(components; idealmodel=BasicIdeal, userlocations=String[], id
     packagedparams = SAFTVRMieParam(segment, sigma, lambda_a, lambda_r, epsilon, epsilon_assoc, bondvol, Mw)
     references = ["10.1063/1.4819786", "10.1080/00268976.2015.1029027"]
 
-    model = SAFTVRMie(packagedparams, sites, idealmodel; ideal_userlocations=ideal_userlocations, references=references, verbose=verbose)
+    model = SAFTVRMie(packagedparams, sites, idealmodel; ideal_userlocations, references, verbose, assoc_options)
     return model
 end
 

--- a/src/models/eos/SAFT/SAFTVRSW/SAFTVRSW.jl
+++ b/src/models/eos/SAFT/SAFTVRSW/SAFTVRSW.jl
@@ -12,7 +12,13 @@ abstract type SAFTVRSWModel <: SAFTModel end
 @newmodel SAFTVRSW SAFTVRSWModel SAFTVRSWParam
 
 export SAFTVRSW
-function SAFTVRSW(components; idealmodel=BasicIdeal, userlocations=String[], ideal_userlocations=String[], verbose=false)
+function SAFTVRSW(components;
+    idealmodel=BasicIdeal,
+    userlocations=String[],
+    ideal_userlocations=String[],
+    verbose=false,
+    assoc_options = AssocOptions())
+
     params,sites = getparams(components, ["SAFT/SAFTVRSW","properties/molarmass.csv"]; userlocations=userlocations, verbose=verbose)
 
     segment = params["m"]
@@ -29,7 +35,7 @@ function SAFTVRSW(components; idealmodel=BasicIdeal, userlocations=String[], ide
     packagedparams = SAFTVRSWParam(Mw, segment, sigma, lambda, epsilon, epsilon_assoc, bondvol)
     references = ["todo"]
 
-    model = SAFTVRSW(packagedparams, sites, idealmodel; ideal_userlocations=ideal_userlocations, references=references, verbose=verbose)
+    model = SAFTVRSW(packagedparams, sites, idealmodel; ideal_userlocations, references, verbose, assoc_options)
     return model
 end
 

--- a/src/models/eos/SAFT/SAFTgammaMie/SAFTgammaMie.jl
+++ b/src/models/eos/SAFT/SAFTgammaMie/SAFTgammaMie.jl
@@ -32,7 +32,7 @@ struct SAFTgammaMie{I,VR} <: SAFTgammaMieModel
     idealmodel::I
     vrmodel::VR
     mie_zfractions::γMieZ
-    absolutetolerance::Float64
+    assoc_options::AssocOptions
     references::Array{String,1}
 end
 
@@ -58,7 +58,7 @@ function SAFTgammaMie(components;
     userlocations=String[],
     ideal_userlocations=String[],
     verbose=false,
-    absolutetolerance = 1e-12)
+    assoc_options = AssocOptions())
 
     groups = GroupParam(components, ["SAFT/SAFTgammaMie/SAFTgammaMie_groups.csv"]; verbose=verbose)
     params,sites = getparams(groups, ["SAFT/SAFTgammaMie","properties/molarmass_groups.csv"]; userlocations=userlocations, verbose=verbose)
@@ -175,11 +175,11 @@ function SAFTgammaMie(components;
     _mw = SingleParam("molecular_weight",components,comp_mw)
     gcparams = SAFTgammaMieParam(gc_segment,gc_mixedsegment, shapefactor,gc_lambda_a,gc_lambda_r,gc_sigma,gc_epsilon,gc_epsilon_assoc,gc_bondvol)
     vrparams = SAFTVRMieParam(segment,sigma,lambda_a,lambda_r,epsilon,comp_epsilon_assoc,comp_bondvol,_mw)
-    vr = SAFTVRMie(vrparams, comp_sites, BasicIdeal(); ideal_userlocations=ideal_userlocations, verbose=verbose)
     idmodel = init_model(idealmodel,components,ideal_userlocations,verbose)
+    vr = SAFTVRMie(vrparams, comp_sites, idmodel; ideal_userlocations, verbose, assoc_options)
     mie_z = γMieZ(components,zzparam)
     γmierefs = ["10.1063/1.4851455", "10.1021/je500248h"]
-    gmie = SAFTgammaMie(components,groups,sites,gcparams,idmodel,vr,mie_z,absolutetolerance,γmierefs)
+    gmie = SAFTgammaMie(components,groups,sites,gcparams,idmodel,vr,mie_z,assoc_options,γmierefs)
     return gmie
 end
 @registermodel SAFTgammaMie

--- a/src/models/eos/SAFT/equations.jl
+++ b/src/models/eos/SAFT/equations.jl
@@ -54,7 +54,6 @@ end
 
 function X(model::Union{SAFTModel,CPAModel}, V, T, z,data = nothing)
     _1 = one(V+T+first(z))
-    tol = model.absolutetolerance
     X_ = PackedVectorsOfVectors.packed_ones(typeof(_1),length(@sites(i)) for i ∈ @comps)
     idxs = indices(X_)    
     X0 = X_.v
@@ -77,7 +76,13 @@ function X(model::Union{SAFTModel,CPAModel}, V, T, z,data = nothing)
         _Δ = @f(Δ,data)
     end  
     fX(out,in) = X!(out,in,idxs,_Δ,model.sites,ρ,z)
-    Xsol = Solvers.fixpoint(fX,X0,Solvers.SSFixPoint(0.5),atol=tol,max_iters = 1000)
+
+    options = model.assoc_options
+    atol = options.atol
+    rtol = options.rtol
+    max_iters = options.max_iters
+    α = options.dampingfactor
+    Xsol = Solvers.fixpoint(fX,X0,Solvers.SSFixPoint(α),atol=atol,rtol = rtol,max_iters = max_iters)
     return PackedVofV(idxs,Xsol)
 end
 

--- a/src/models/eos/SAFT/ogSAFT/ogSAFT.jl
+++ b/src/models/eos/SAFT/ogSAFT/ogSAFT.jl
@@ -10,7 +10,13 @@ abstract type ogSAFTModel <: SAFTModel end
 @newmodel ogSAFT ogSAFTModel ogSAFTParam
 
 export ogSAFT
-function ogSAFT(components; idealmodel=BasicIdeal, userlocations=String[], ideal_userlocations=String[], verbose=false)
+function ogSAFT(components;
+    idealmodel=BasicIdeal,
+    userlocations=String[],
+    ideal_userlocations=String[],
+    verbose=false,
+    assoc_options = AssocOptions())
+
     params,sites = getparams(components, ["SAFT/ogSAFT"]; userlocations=userlocations, verbose=verbose)
     segment = params["m"]
     k = params["k"]
@@ -23,7 +29,7 @@ function ogSAFT(components; idealmodel=BasicIdeal, userlocations=String[], ideal
     packagedparams = ogSAFTParam(segment, sigma, epsilon, epsilon_assoc, bondvol)
     references = ["todo"]
 
-    model = ogSAFT(packagedparams, sites, idealmodel; ideal_userlocations=ideal_userlocations, references=references, verbose=verbose)
+    model = ogSAFT(packagedparams, sites, idealmodel; ideal_userlocations, references, verbose, assoc_options)
     return model
 end
 

--- a/src/models/eos/SAFT/softSAFT/softSAFT.jl
+++ b/src/models/eos/SAFT/softSAFT/softSAFT.jl
@@ -10,7 +10,13 @@ abstract type softSAFTModel <: SAFTModel end
 @newmodel softSAFT softSAFTModel softSAFTParam
 
 export softSAFT
-function softSAFT(components; idealmodel=BasicIdeal, userlocations=String[], ideal_userlocations=String[], verbose=false)
+function softSAFT(components;
+    idealmodel=BasicIdeal,
+    userlocations=String[],
+    ideal_userlocations=String[],
+    verbose=false,
+    assoc_options = AssocOptions())
+
     params,sites = getparams(components, ["SAFT/softSAFT"]; userlocations=userlocations, verbose=verbose)
     
     segment = params["m"]
@@ -24,7 +30,7 @@ function softSAFT(components; idealmodel=BasicIdeal, userlocations=String[], ide
     packagedparams = softSAFTParam(segment, sigma, epsilon, epsilon_assoc, bondvol)
     references = ["todo"]
 
-    model = softSAFT(packagedparams, sites, idealmodel; ideal_userlocations=ideal_userlocations, references=references, verbose=verbose)
+    model = softSAFT(packagedparams, sites, idealmodel; ideal_userlocations, references, verbose, assoc_options)
     return model
 end
 

--- a/src/solvers/Solvers.jl
+++ b/src/solvers/Solvers.jl
@@ -105,14 +105,22 @@ import NaNMath
 
     @inline log(x::Number) = Base.log(x)
     @inline log(x::Complex) = Base.log(x)
-    @inline log(x::Real) = ifelse(x>=zero(x),Base.log(x),zero(x)/zero(x))
-    @inline log(x::Float64) = NaNMath.log(x)
-    @inline log(x::Float32) = NaNMath.log(x)
-    @inline log(x::Int8) = NaNMath.log(float(x))
-    @inline log(x::Int16) = NaNMath.log(float(x))
-    @inline log(x::Int32) = NaNMath.log(float(x))
-    @inline log(x::Int64) = NaNMath.log(float(x))
+
+    @inline function log(x::T) where T <:Real
+            _0 = zero(x)
+            ifelse(x>=zero(x),Base.log(max(_0,x)),_0/_0)
+        end
+    #@inline log(x::Float64) = NaNMath.log(x)
+    #@inline log(x::Float32) = NaNMath.log(x)
+    #@inline log(x::Int8) = NaNMath.log(float(x))
+    #@inline log(x::Int16) = NaNMath.log(float(x))
+    #@inline log(x::Int32) = NaNMath.log(float(x))
+    #@inline log(x::Int64) = NaNMath.log(float(x))
     
+    @inline function sqrt(x::T) where T <:Real
+        _0 = zero(x)
+        ifelse(x>=zero(x),Base.sqrt(max(_0,x)),_0/_0)
+    end
     include("ADNewton.jl")
     include("nlsolve.jl")
     include("fixpoint/fixpoint.jl")

--- a/src/solvers/Solvers.jl
+++ b/src/solvers/Solvers.jl
@@ -54,7 +54,7 @@ import NaNMath
         #B   =  E12 - 3*E2                 # = s1 s2
         # quadratic equation: z^2 - Az + B^3=0  where roots are equal to s1^3 and s2^3
         Δ2 = det_22(A,A,4*B*B,B)
-        Δ = sqrt(Δ2)
+        Δ = Base.sqrt(Δ2)
         #Δ = (A*A - 4*B*B*B)^0.5
         if real(conj(A)*Δ)>=0 # scalar product to decide the sign yielding bigger magnitude
             s1 = exp(log(0.5 * (A + Δ)) * third)
@@ -103,8 +103,7 @@ import NaNMath
         return res.info.minimizer
     end
 
-    @inline log(x::Number) = Base.log(x)
-    @inline log(x::Complex) = Base.log(x)
+    @inline log(x) = Base.log(x)
 
     @inline function log(x::T) where T <:Real
             _0 = zero(x)
@@ -116,7 +115,7 @@ import NaNMath
     #@inline log(x::Int16) = NaNMath.log(float(x))
     #@inline log(x::Int32) = NaNMath.log(float(x))
     #@inline log(x::Int64) = NaNMath.log(float(x))
-    
+    @inline sqrt(x) = Base.sqrt(x)
     @inline function sqrt(x::T) where T <:Real
         _0 = zero(x)
         ifelse(x>=zero(x),Base.sqrt(max(_0,x)),_0/_0)

--- a/src/utils/ClapeyronParam.jl
+++ b/src/utils/ClapeyronParam.jl
@@ -631,6 +631,21 @@ function SiteParam(components::Vector{String})
     String[])
 end
 
+"""
+    AssocOptions(;rtol = 1e-12,atol = 1e-12,max_iters = 1000,dampingfactor = 0.5)
+
+Struct containing iteration parameters for the solver of association sites.
+
+"""
+@Base.kwdef struct AssocOptions <: ClapeyronParam
+    rtol::Float64 = 1e-12
+    atol::Float64 = 1e-12
+    max_iters::Int = 1000
+    dampingfactor::Float64 = 0.5
+end
+
+is_splittable(::AssocOptions) = false
+
 paramvals(param::ClapeyronParam) = param.values
 paramvals(x) = x
 

--- a/src/utils/macros.jl
+++ b/src/utils/macros.jl
@@ -139,7 +139,7 @@ The Struct consists of the following fields:
 * sites: a [`SiteParam`](@ref)
 * params: the Struct paramstype that contains all parameters in the model
 * idealmodel: the IdealModel struct that determines which ideal model to use
-* absolutetolerance: the absolute tolerance for solvers; the default value is 1E-12
+* assoc_options: struct containing options for the association solver. see [AssocOptions](@ref)
 * references: reference for this EoS
 
 See the tutorial or browse the implementations to see how this is used.
@@ -153,7 +153,7 @@ macro newmodelgc(name, parent, paramstype)
         sites::SiteParam
         params::$paramstype
         idealmodel::T
-        absolutetolerance::Float64
+        assoc_options::AssocOptions
         references::Array{String,1}
     end
 
@@ -193,7 +193,7 @@ macro newmodel(name, parent, paramstype)
         sites::SiteParam
         params::$paramstype
         idealmodel::T
-        absolutetolerance::Float64
+        assoc_options::AssocOptions
         references::Array{String,1}
     end
     has_sites(::Type{<:$name}) = true
@@ -224,7 +224,6 @@ macro newmodelsimple(name, parent, paramstype)
         components::Array{String,1}
         icomponents::UnitRange{Int}
         params::$paramstype
-        absolutetolerance::Float64
         references::Array{String,1}
     end
     has_sites(::Type{<:$name}) = false
@@ -252,7 +251,7 @@ function (::Type{model})(params::EoSParam,
         idealmodel::IDEALTYPE = BasicIdeal;
         ideal_userlocations::Vector{String}=String[],
         references::Vector{String}=String[],
-        absolutetolerance::Float64 = 1e-12,
+        assoc_options::AssocOptions = AssocOptions(),
         verbose::Bool = false) where model <:EoSModel
 
         components = groups.components
@@ -261,7 +260,7 @@ function (::Type{model})(params::EoSParam,
         return model(components, icomponents,
         groups,
         sites,
-        params, init_idealmodel, absolutetolerance, references)
+        params, init_idealmodel, assoc_options, references)
 end
 
 function (::Type{model})(params::EoSParam,
@@ -269,11 +268,11 @@ function (::Type{model})(params::EoSParam,
         idealmodel::IDEALTYPE = BasicIdeal;
         ideal_userlocations::Vector{String}=String[],
         references::Vector{String}=String[],
-        absolutetolerance::Float64 = 1e-12,
+        assoc_options::AssocOptions = AssocOptions(),
         verbose::Bool = false) where model <:EoSModel
 
     sites = SiteParam(groups.components)
-    return model(params,groups,sites,idealmodel;ideal_userlocations,references,absolutetolerance,verbose)
+    return model(params,groups,sites,idealmodel;ideal_userlocations,references,assoc_options,verbose)
 end
 
 #non GC
@@ -282,7 +281,7 @@ function (::Type{model})(params::EoSParam,
         idealmodel::IDEALTYPE = BasicIdeal;
         ideal_userlocations::Vector{String}=String[],
         references::Vector{String}=String[],
-        absolutetolerance::Float64 = 1e-12,
+        assoc_options::AssocOptions = AssocOptions(),
         verbose::Bool = false) where model <:EoSModel
     
     components = sites.components
@@ -290,7 +289,7 @@ function (::Type{model})(params::EoSParam,
 
     init_idealmodel = init_model(idealmodel,components,ideal_userlocations,verbose)
     return model(components, icomponents,
-    sites, params, init_idealmodel, absolutetolerance, references)
+    sites, params, init_idealmodel, assoc_options, references)
 
 end
 
@@ -299,16 +298,14 @@ function (::Type{model})(params::EoSParam,
         idealmodel::IDEALTYPE = BasicIdeal;
         ideal_userlocations::Vector{String}=String[],
         references::Vector{String}=String[],
-        absolutetolerance::Float64 = 1e-12,
+        assoc_options::AssocOptions = AssocOptions(),
         verbose::Bool = false) where model <:EoSModel
 
-    
-    
     if has_sites(model)
         arbparam = arbitraryparam(params)
         components = arbparam.components
         sites = SiteParam(components)
-        return model(params,sites,idealmodel;ideal_userlocations,references,absolutetolerance,verbose)
+        return model(params,sites,idealmodel;ideal_userlocations,references,assoc_options,verbose)
     end
     #With sites out of the way, this is a simplemodel, no need to initialize the ideal model
     #if there isnt any params, just put empty values.
@@ -320,8 +317,7 @@ function (::Type{model})(params::EoSParam,
         components = String[]
         icomponents =1:0
     end
-    return model(components,icomponents,params,absolutetolerance,references)
-
+    return model(components,icomponents,params,references)
 end
 
 function init_model(idealmodel::IdealModel,components,userlocations,verbose)

--- a/src/utils/split_model.jl
+++ b/src/utils/split_model.jl
@@ -171,7 +171,7 @@ function auto_split_model(Base.@nospecialize(model::EoSModel),subset=nothing)
             raw_splitter = model.groups.i_groups
             subset !== nothing && throw("using subsets is not supported with Group Contribution models")
         else
-            raw_splitter = split_model(1:length(model.components))
+            raw_splitter = split_model(Vector(1:length(model.components)))
         end
         if subset === nothing
             splitter = raw_splitter
@@ -185,7 +185,6 @@ function auto_split_model(Base.@nospecialize(model::EoSModel),subset=nothing)
         
         len = length(splitter)
         M = typeof(model)
-
         if hasfield(typeof(model),:groups) #TODO implement a splitter that accepts a subset
             allfields[:groups] = split_model(model.groups)
         end


### PR DESCRIPTION
fixes #54 
to each site EoS model, there is now a new keyword, `assoc_options` containing an `AssocOptions` struct of the form:
```julia
assoc_options = AssocOptions(atol = 1e-12,rtol = 1e-12,max_iters = 1000, dampingfactor = 0.5)
```
if one need to increase the max iterations of an specific model, now you could just do:
```julia
model = PCSAFT(components,assoc_options = AssocOptions(max_iters = 10000))
```
as a byproduct, `split_model` was refactored to be a little bit more general. the only special case we do now is the references field.

Also, there is take 3 of trying to improve NaN handling. the problem was that `ForwardDiff.Dual`s wasn't being processed by our custom `log` (and now `sqrt`). with the new definitions, NaNMath is no longer used, and can be safely removed in a subsequent commit.
It seems that our previous saturation pressure solver wasn't robust enough, as now there aren't any errors in the test suite with the default `log` implementation.  

i will merge after #56 
