### PR TITLE
made PR autodiffable, like  RK

### DIFF
--- a/src/models/cubic/PR/PR.jl
+++ b/src/models/cubic/PR/PR.jl
@@ -78,7 +78,7 @@ function cubic_poly(model::PRModel,p,T,z)
     k₀ = B*(B*(B+1.0)-A)
     k₁ = -B*(3*B+2.0) + A
     k₂ = B-1.0
-    k₃ = 1.0
+    k₃ = one(a) # important to enable autodiff
     return (k₀,k₁,k₂,k₃),c
 end
 #=


### PR DESCRIPTION
Hi, 
I changed the definition of k3 to be of the same type as the other parameters. This is done similarly in the RK-cubic model. 

This is important for forwardDiff calls through the p,T functions like: 
`dHdT(model,p,T,n) = ForwardDiff.derivative(dT-> Clapeyron.enthalpy(model,p,dT,n ),T)`
which are now possible for  PR-models as well.