### PR TITLE
add nitrous oxide molar mass

### DIFF
--- a/database/properties/molarmass.csv
+++ b/database/properties/molarmass.csv
@@ -548,3 +548,4 @@ aniline,,93.13
 acetic acid,,60.053
 neon,,20.1797
 sulfur hexafluoride,,146.055
+nitrous oxide,,44.013


### PR DESCRIPTION
already exists in critical, though capitalisation is different. Afaik capitalisation plays no role in database lookup here anyway.