### PR TITLE
Add chemical stability check

### DIFF
--- a/src/Clapeyron.jl
+++ b/src/Clapeyron.jl
@@ -12,8 +12,6 @@ using FillArrays: FillArrays
 using Roots: Roots
 using NLSolvers
 import BlackBoxOptim
-# For minimizing tangent plane distance function
-using Optim
 
 using DiffResults, ForwardDiff
 using Scratch 

--- a/src/Clapeyron.jl
+++ b/src/Clapeyron.jl
@@ -12,6 +12,9 @@ using FillArrays: FillArrays
 using Roots: Roots
 using NLSolvers
 import BlackBoxOptim
+# For minimizing tangent plane distance function
+using Optim
+
 using DiffResults, ForwardDiff
 using Scratch 
 using Unitful

--- a/src/methods/stability.jl
+++ b/src/methods/stability.jl
@@ -71,8 +71,6 @@ function gibbs_duhem(model,V,T,z=SA[1.0])
     return abs(μ-g),μ,g
 end
 
-export isstable, mechanical_stability, diffusive_stability, gibbs_duhem
-
 """
     chemical_stability(model,V,T,z)::Bool
 Performs a chemical stability check using the 
@@ -91,8 +89,8 @@ function chemical_stability(model::EoSModel,p,T,z)
 
     tdp_func(w,phase) = Optim.minimum(optimize(w -> 
                             tangent_plane_distance(model,p,T,z,phase,w), w))
-    tdp = tdp_func(w_vap), tdp_func(w_liq)
-    if any(tdp > 0)
+    tdp = [tdp_func(w_vap,:v), tdp_func(w_liq,:l)]
+    if any(tdp .> 0)
         return true
     else
         return false
@@ -104,10 +102,13 @@ end
 Calculates the tangent plane distance for a tangent plane stability test
 Uses unconstrained minimisation from NLSolvers.jl
 """
-function tangent_plane_distance(model,p,T,z,w)
+function tangent_plane_distance(model,p,T,z,phase,w)
     w = w./sum(w)
     V = volume(model, p, T, w;phase=phase)
 
     μ(w) = Clapeyron.VT_chemical_potential(model,V,T,w)
     tdp = sum(w.*(μ(w) .- μ(z)))#./(8.314*T)
 end
+
+export isstable, mechanical_stability, diffusive_stability, gibbs_duhem, chemical_stability
+

--- a/src/methods/stability.jl
+++ b/src/methods/stability.jl
@@ -89,7 +89,8 @@ function chemical_stability(model::EoSModel,p,T,z)
     w_vap = Kʷ.*z
     w_liq = z./Kʷ
 
-    tdp_func(w) = Optim.minimum(optimize(w -> tangent_plane_distance(model,p,T,z,w), z))
+    tdp_func(w,phase) = Optim.minimum(optimize(w -> 
+                            tangent_plane_distance(model,p,T,z,phase,w), w))
     tdp = tdp_func(w_vap), tdp_func(w_liq)
     if any(tdp > 0)
         return true
@@ -105,9 +106,8 @@ Uses unconstrained minimisation from NLSolvers.jl
 """
 function tangent_plane_distance(model,p,T,z,w)
     w = w./sum(w)
-    V = volume(model, p, T, w)
+    V = volume(model, p, T, w;phase=phase)
 
     μ(w) = Clapeyron.VT_chemical_potential(model,V,T,w)
-
-    tdp = sum(w.*(μ(w) .- μ(z)))./(8.314*T)
+    tdp = sum(w.*(μ(w) .- μ(z)))#./(8.314*T)
 end

--- a/src/methods/stability.jl
+++ b/src/methods/stability.jl
@@ -21,6 +21,10 @@ function isstable(model,V,T,z,phase=:stable)
         @warn "StabilityWarning: Phase is diffusively unstable"
         stable = false
     end
+    if !chemical_stability(model,V,T,z)
+        @warn "StabilityWarning: Phase is chemically unstable"
+        stable = false
+    end
     return stable
 end
 
@@ -69,4 +73,41 @@ end
 
 export isstable, mechanical_stability, diffusive_stability, gibbs_duhem
 
+"""
+    chemical_stability(model,V,T,z)::Bool
+Performs a chemical stability check using the 
+"""
+function chemical_stability(model::EoSModel,p,T,z)
+    # Generate vapourlike and liquidlike initial guesses
+    # Currently using Wilson correlation
+    Pc = model.params.Pc.values
+    Tc = model.params.Tc.values
+    ω = model.alpha.params.acentricfactor.values
 
+    Kʷ = @. Pc/p*exp(5.373*(1+ω)*(1-Tc/T))
+    z = z./sum(z)
+    w_vap = Kʷ.*z
+    w_liq = z./Kʷ
+
+    tdp_func(w) = Optim.minimum(optimize(w -> tangent_plane_distance(model,p,T,z,w), z))
+    tdp = tdp_func(w_vap), tdp_func(w_liq)
+    if any(tdp > 0)
+        return true
+    else
+        return false
+    end
+end
+
+"""
+    tangent_plane_distance(model,V,T,z)::Float
+Calculates the tangent plane distance for a tangent plane stability test
+Uses unconstrained minimisation from NLSolvers.jl
+"""
+function tangent_plane_distance(model,p,T,z,w)
+    w = w./sum(w)
+    V = volume(model, p, T, w)
+
+    μ(w) = Clapeyron.VT_chemical_potential(model,V,T,w)
+
+    tdp = sum(w.*(μ(w) .- μ(z)))./(8.314*T)
+end

--- a/src/solvers/ad.jl
+++ b/src/solvers/ad.jl
@@ -92,3 +92,8 @@ function ∂2(f::F,x1::R1,x2::R2) where{F,R1<:Real,R2<:Real}
     y1,y2 = promote(x1,x2)
     return ∂2(f,y1,y2)
 end
+
+function autochunk(x)
+    k = ForwardDiff.pickchunksize(length(x))
+    return ForwardDiff.Chunk{k}()
+end

--- a/src/solvers/optimize.jl
+++ b/src/solvers/optimize.jl
@@ -1,5 +1,5 @@
 
-function ADScalarObjective(f,x0::AbstractArray)
+function ADScalarObjective(f,x0::AbstractArray,chunk = autochunk(x0))
     Hres = DiffResults.HessianResult(x0)
     function _g(df,x,Hresult)
         ForwardDiff.gradient!(Hresult,f,x)
@@ -65,8 +65,12 @@ end
 """
     function optimize(f,x0,method=LineSearch(Newton()), options=OptimizationOptions())
 """
-function optimize(f,x0::Number,method=LineSearch(Newton()),options=OptimizationOptions())
-    scalarobj = ADScalarObjective(f,x0)   
+=#
+
+function optimize(f,x0,method=LineSearch(Newton()),chunk =autochunk(x0),options=OptimizationOptions())
+    scalarobj = ADScalarObjective(f,x0,chunk)   
     optprob = OptimizationProblem(scalarobj; inplace=false) 
     return NLSolvers.solve(optprob, x0, method,options)
-end=#
+end
+
+x_minimum(res::NLSolvers.ConvergenceInfo) = res.info.minimum


### PR DESCRIPTION
Added a chemical stability check. This returns a boolean distance based off of the unconstrained minimization of tangent plane distance function, TDP(w). If this is non-negative for any trial phase composition w, i.e. min(TDP) >= 0, then the chemical stability function returns true.

Issues:
This currently adds a new dependency of Optim.jl, which is likely unnecessary considering BlackBoxOptim is already present, as well as not constraining results to mole fractions in (0,1).
On top of this, I am suspect of the reliability of this and need to add both test cases, as well as validate the tangent plane distance function against a more traditional fugacity coefficient based form.
