### PR TITLE
bounded RR and ASS in TP flash

### DIFF
--- a/src/Clapeyron.jl
+++ b/src/Clapeyron.jl
@@ -63,6 +63,9 @@ include("utils/index_reduction.jl")
 #splitting models, useful for methods.
 include("utils/split_model.jl")
 
+# Gustavo: acceleration for successive substitution
+include("utils/acceleration_ss.jl")
+
 #Clapeyron methods (AD, property solvers, etc)
 include("methods/methods.jl")
 

--- a/src/methods/fugacity_coefficient.jl
+++ b/src/methods/fugacity_coefficient.jl
@@ -1,8 +1,9 @@
 # Function to compute fugacity coefficient
 function lnϕ(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, vol0=nothing)
     RT = R̄*T
-    vol0 === nothing && (vol0 = x0_volume(model, p, T, z, phase = phase))
-    vol = _volume_compress(model,p,T,z,vol0)
+    # vol0 === nothing && (vol0 = x0_volume(model, p, T, z, phase = phase))
+    # vol = _volume_compress(model,p,T,z,vol0)
+    vol = volume(model, p, T, z, phase=phase, vol0=vol0)
     μ_res = VT_chemical_potential_res(model, vol, T, z)
     Z = p*vol/RT/sum(z)
     lnϕ = μ_res/RT .- log(Z)

--- a/src/methods/property_solvers/multicomponent/tp_flash/Michelsentp_flash.jl
+++ b/src/methods/property_solvers/multicomponent/tp_flash/Michelsentp_flash.jl
@@ -1,5 +1,4 @@
-#=
-function rachfordrice(β, K, z)
+function rachfordrice(K, z; β0=nothing)
     # Function to solve Rachdord-Rice mass balance
     K1 = K .- 1.
     g0 = dot(z, K) - 1.
@@ -17,24 +16,52 @@ function rachfordrice(β, K, z)
         singlephase = true
     end
 
+    βmin = max(0., minimum(((K.*z .- 1) ./ (K .-  1.))[K .> 1]))
+    βmax = min(1., maximum(((1 .- z) ./ (1. .- K))[K .< 1]))
+
+    if isnothing(β0)
+        β = (βmax + βmin)/2
+    else
+        β = 1. * β0
+    end
+
     # Solving the phase fraction β using Halley's method
     it = 0
-    error = 1.
-    while error > 1e-8 && it < 10 &&  ~singlephase
+    error_β = 1.
+    error_FO = 1.
+    while error_β > 1e-8 && error_FO > 1e-8 && it < 10 &&  ~singlephase
         it = it + 1
         D = 1. .+ β.*K1
         KD = K1./D
         FO = dot(z, KD)
         dFO = - dot(z, KD.^2)
-        d2FO = 2. *dot(z, KD.^3)
+        d2FO = 2. * dot(z, KD.^3)
         dβ = - (2*FO*dFO)/(2*dFO^2-FO*d2FO)
-        β = β + dβ
-        error = abs(dβ)
+
+        # restricted β space
+        if FO < 0.
+            βmax = β
+        elseif FO > 0.
+            βmin = β
+        end
+
+        #updatind β
+        βnew =  β + dβ
+        if βmin < βnew && βnew < βmax
+            β = βnew
+        else
+            dβ = (βmin + βmax) / 2 - β
+            β = dβ + β
+        end
+
+        error_β = abs(dβ)
+        error_FO = abs(FO)
+
     end
-    return β, D, singlephase
+    return β
 end
 
-=#
+
 function gibbs_obj!(model::EoSModel, p, T, z, phasex, phasey, ny, vcache; F=nothing, G=nothing)
     # Objetive Function to minimize the Gibbs Free Energy
     # It computes the Gibbs free energy and its gradient
@@ -136,6 +163,7 @@ Only two phases are supported. if `K0` is `nothing`, it will be calculated via t
 - `vol0` = optional, initial guesses for phase x and phase y volumes
 - `K_tol` = tolerance to stop the calculation
 - `ss_iters` = number of Successive Substitution iterations to perform
+- `nacc` =  accelerate successive substitution method every nacc steps. Should be a integer bigger than 3. Set to 0 for no acceleration. 
 - `second_order` = wheter to solve the gibbs energy minimization using the analytical hessian or not
 - `noncondensables` = arrays with names (strings) of components non allowed on the liquid phase. Not allowed with `lle` equilibria
 - `nonvolatiles` = arrays with names (strings) of components non allowed on the vapour phase. Not allowed with `lle` equilibria
@@ -149,6 +177,7 @@ struct MichelsenTPFlash{T} <: TPFlashMethod
     v0::Union{Tuple{T,T},Nothing}
     K_tol::Float64
     ss_iters::Int
+    nacc::Int
     second_order::Bool
     noncondensables::Union{Nothing,Vector{String}}
     nonvolatiles::Union{Nothing,Vector{String}}
@@ -170,8 +199,9 @@ function MichelsenTPFlash(;equilibrium = :vle,
                         x0 = nothing,
                         y0=nothing,
                         v0=nothing,
-                        K_tol = eps(Float64),
-                        ss_iters = 10,
+                        K_tol = sqrt(eps(Float64)),
+                        ss_iters = 21,
+                        nacc = 5,
                         second_order = false,
                         noncondensables = nothing,
                         nonvolatiles = nothing)
@@ -201,7 +231,7 @@ function MichelsenTPFlash(;equilibrium = :vle,
         end
     end
 
-    return MichelsenTPFlash{T}(equilibrium,K0,x0,y0,v0,K_tol,ss_iters,second_order,noncondensables,nonvolatiles)
+    return MichelsenTPFlash{T}(equilibrium,K0,x0,y0,v0,K_tol,ss_iters,nacc,second_order,noncondensables,nonvolatiles)
 end
 
 is_vle(method::MichelsenTPFlash) = is_vle(method.equilibrium)
@@ -221,12 +251,14 @@ function tp_flash_impl(model::EoSModel,p,T,z,method::MichelsenTPFlash)
     if !modified
         x,y,β =  tp_flash_michelsen(model,p,T,z;equilibrium = method.equilibrium, K0 = method.K0,
                             x0 = method.x0, y0 = method.y0, vol0 = method.v0,
-                            K_tol = method.K_tol,itss = method.ss_iters,second_order = method.second_order,
+                            K_tol = method.K_tol,itss = method.ss_iters, nacc=method.nacc,
+                            second_order = method.second_order,
                             reduced = true)
     else
         x,y,β =  tp_flash_michelsen_modified(model,p,T,z;equilibrium = method.equilibrium, K0 = method.K0,
                         x0 = method.x0, y0 = method.y0, vol0 = method.v0,
-                        K_tol = method.K_tol,itss = method.ss_iters,second_order = method.second_order,
+                        K_tol = method.K_tol,itss = method.ss_iters, nacc=method.nacc,
+                        second_order = method.second_order,
                         non_inx_list=method.noncondensables, non_iny_list=method.nonvolatiles, reduced = true)
     end
 
@@ -241,7 +273,7 @@ end
 
 function tp_flash_michelsen(model::EoSModel, p, T, z; equilibrium=:vle, K0=nothing,
                             x0=nothing, y0=nothing, vol0=(nothing, nothing),
-                            K_tol=1e-16, itss=10, second_order=false, reduced = false)
+                            K_tol=1e-8, itss=21, nacc=5, second_order=false, reduced = false)
 
     if !reduced
         model_full,z_full = model,z
@@ -281,41 +313,38 @@ function tp_flash_michelsen(model::EoSModel, p, T, z; equilibrium=:vle, K0=nothi
                         or for compositions of x and y for LLE""")
         err()
     end
+
+    # type stability
     _1 = one(p+T+first(z))
+
     # Initial guess for phase split
-    βmin = max(0., minimum(((K.*z .- 1) ./ (K .-  1.))[K .> 1]))
-    βmax = min(1., maximum(((1 .- z) ./ (1. .- K))[K .< 1]))
-    β = _1*(βmin + βmax)/2
-    # Stage 1: Successive Substitution
+    β0 = nothing
+    β = 0.5 * _1 # this is just to have β as a global variable
+
+    # Stage 1: Accelerated Successive Substitution
     it = 0
-    error_lnK = _1
+    error_lnK = copy(_1)
     singlephase = false
     lnK_old = lnK .* _1
     x = similar(z)
     y = similar(z)
+
+    itacc = 0
+    lnK3 = similar(lnK)
+    lnK4 = similar(lnK)
+    lnK5 = similar(lnK)
+    lnK_dem = similar(lnK)
+
+    gibbs = copy(_1)
+    gibbs_dem = copy(_1)
+
     while error_lnK > K_tol && it < itss
+        itacc += 1
         it += 1
         lnK_old .= lnK
 
-        # Solving Rachford-Rice Eq.
-        # Gustavo: for some reason this is diverging, I'll ask Andres about it
-        # β = rr_vle_vapor_fraction(K, z)
-        # for now i will just use Halley's method
-        error_β = _1
-        it_rr = 0
-        while error_β > 1e-8 && it_rr < 10
-            it_rr += 1
-            FOi = (K .- 1) ./ (1. .+ β .* (K .- 1))
-
-            OF = dot(z, FOi)
-            dOF = - dot(z, FOi.^2)
-            d2OF = 2. *dot(z, FOi.^3)
-
-            dβ = - (2*OF*dOF)/(2*dOF^2-OF*d2OF)
-            β = β + dβ
-            error_β = abs(dβ)
-            # println(it_rr, " ", β, " ", dβ, " ", OF)
-        end
+        # solving RR's equations using Halley's method
+        β = rachfordrice(K, z; β0=β0)
 
         singlephase = !(0 <= β <= 1)
         # Recomputing phase composition
@@ -327,17 +356,59 @@ function tp_flash_michelsen(model::EoSModel, p, T, z; equilibrium=:vle, K0=nothi
         lnϕx, volx = lnϕ(model, p, T, x; phase=phasex, vol0=volx)
         lnϕy, voly = lnϕ(model, p, T, y; phase=phasey, vol0=voly)
         lnK .= lnϕx .- lnϕy
-        K .= exp.(lnK)
-        # Computing error
-        error_lnK = dnorm(lnK,lnK_old,1)
-    end
 
-    # println(β, " ", x, " ", y, " ", z)
+        # computing current Gibbs free energy 
+        gibbs = β * sum(y .* (log.(y) .+ lnϕy)) 
+        gibbs += (1. - β) * sum(x .* (log.(x) .+ lnϕx))
+        
+        # acceleration step
+        if itacc == (nacc - 2)
+            lnK3 = 1. * lnK
+        elseif itacc == (nacc - 1)
+            lnK4 = 1. * lnK
+        elseif itacc == nacc
+            itacc = 0
+            lnK5 = 1. * lnK
+            # acceleration using DEM (1 eigenvalues)
+            lnK_dem = dem(lnK5, lnK4, lnK3)
+            K_dem = exp.(lnK_dem)
+            # requires to solve the RR problem again (to compute the 
+            # extrapolated Gibbs free energy)
+            β_dem = rachfordrice(K_dem, z; β0=β)
+            x_dem = similar(x)
+            x_dem = rr_flash_liquid!(x_dem,K_dem,z,β_dem)
+            y_dem = x_dem .* K_dem
+            x_dem ./= sum(x_dem)
+            y_dem ./= sum(y_dem)
+
+            lnϕx_dem, volx_dem = lnϕ(model, p, T, x_dem; phase=phasex, vol0=volx)
+            lnϕy_dem, voly_dem = lnϕ(model, p, T, y_dem; phase=phasey, vol0=voly)
+
+            # computing the extrapolated Gibbs free energy
+            gibbs_dem = β_dem * sum(y_dem .* (log.(y_dem) .+ lnϕy_dem)) 
+            gibbs_dem += (1. - β_dem) * sum(x_dem .* (log.(x_dem) .+ lnϕx_dem))
+
+            # only accelerate if the gibbs free energy is reduced
+            if gibbs_dem < gibbs 
+                lnK = _1 * lnK_dem
+                volx = _1 * volx_dem
+                voly = _1 * voly_dem
+                β = _1 * β_dem
+            end
+        end
+        
+        K .= exp.(lnK)
+        # updating future initial guess for the phase fraction 
+        β0 = _1 * β
+        # Computing error
+        # error_lnK = dnorm(lnK,lnK_old,1)
+        error_lnK = sum(abs.(lnK - lnK_old))
+    end
 
     vt = volx,voly
     vcache = Ref{typeof(vt)}(vt)
 
-
+    
     # Stage 2: Minimization of Gibbs Free Energy
     if error_lnK > K_tol && it == itss &&  ~singlephase
         ny = β*y
@@ -363,7 +434,6 @@ function tp_flash_michelsen(model::EoSModel, p, T, z; equilibrium=:vle, K0=nothi
     end
 
     if singlephase
-        # println(β, " ", x, " ", y, " ", z)
         β = zero(β)/zero(β)
         # Gustavo: the fill! function was giving an error
         # fill!(x,z)

--- a/src/models/cubic/equations.jl
+++ b/src/models/cubic/equations.jl
@@ -244,6 +244,12 @@ function volume_impl(model::ABCubicModel,p,T,z=SA[1.0],phase=:unknown,threaded=f
     end
 end
 
+# Gustavo: volume function for volume_impl to work with cubic models
+function volume(model::ABCubicModel,p,T,z=SA[1.0];phase=:unknown,threaded=true,vol0=nothing)
+    return volume_impl(model,p,T,z,phase,threaded,vol0)
+end
+
+
 function zero_pressure_impl(T,a,b,c,Δ1,Δ2,z)
     #0 = R̄*T/(v-b) - a/((v-Δ1*b)*(v-Δ2*b))
     #f(v) = ((v-Δ1*b)*(v-Δ2*b))*R̄*T - (v-b)*a

--- a/src/utils/acceleration_ss.jl
+++ b/src/utils/acceleration_ss.jl
@@ -1,0 +1,25 @@
+# Function to accelerate Succesive Substitution by DEM method (1 eigenvalue)
+function dem(xₙ, xₙ₋₁, xₙ₋₂)
+    Δxₙ₋₁ = xₙ₋₁ .- xₙ₋₂
+    Δxₙ = xₙ .- xₙ₋₁
+    λ = dot(Δxₙ, Δxₙ) / dot(Δxₙ, Δxₙ₋₁)
+    x_dem = xₙ .+ Δxₙ * λ /(1. - λ)
+    return x_dem
+end
+
+# Function to accelerate Succesive Substitution by GDEM method (2 eigenvalues)
+function gdem2(xₙ, xₙ₋₁, xₙ₋₂, xₙ₋₃)
+    Δxₙ₋₂ = xₙ .- xₙ₋₃
+    Δxₙ₋₁ = xₙ .- xₙ₋₂
+    Δxₙ = xₙ .- xₙ₋₁
+    b₀₁ = dot(Δxₙ, Δxₙ₋₁)
+    b₀₂ = dot(Δxₙ, Δxₙ₋₂)
+    b₁₂ = dot(Δxₙ₋₁, Δxₙ₋₂)
+    b₁₁ = dot(Δxₙ₋₁, Δxₙ₋₁)
+    b₂₂ = dot(Δxₙ₋₂, Δxₙ₋₂)
+    den = b₁₁*b₂₂ - b₁₂^2.
+    μ1 = (b₀₂*b₁₂ - b₀₁*b₂₂) / den
+    μ2 = (b₀₁*b₁₂ - b₀₂*b₁₁) / den
+    x_gdem = xₙ .+ (Δxₙ .- μ2 .* Δxₙ₋₁)/(1. + μ1 + μ2)
+    return x_gdem
+end


### PR DESCRIPTION
Hey guys,

I hope you are doing ok. I made some updates to the TP flash. I updated the RR solution procedure, to be bounded between 0 and 1 and  included acceleration into the SS solution procedure.

I also noticed the volume function was not using the analytical procedure for cubic EoS so I also changed that.

Another question that I have, is that when using cubic EoS for some reason by default the interaction parameters are obtained from the PC-SAFT database. Is that intentional?

Regards,
Gustavo