### PR TITLE
breaking changes - Release 0.4

### DIFF
--- a/database/SAFT/BACKSAFT/BACKSAFT_like.csv
+++ b/database/SAFT/BACKSAFT/BACKSAFT_like.csv
@@ -1,6 +1,6 @@
 Clapeyron Database File,,,,,,,,
 PCSAFT Like Parameters,,,,,,,,
-species,DIPPR Number,Mw,m,c,vol,epsilon,alpha,source
+species,DIPPR Number,Mw,segment,c,vol,epsilon,alpha,source
 argon,,16,1.000,1.,12.08,149.2,1.000,
 nitrogen,,30,1.000,1.,14.05,128.9,1.031,
 oxygen,,44,1.000,1.,11.80,155.9,1.017,

--- a/database/SAFT/CKSAFT/CKSAFT_like.csv
+++ b/database/SAFT/CKSAFT/CKSAFT_like.csv
@@ -1,6 +1,6 @@
 Clapeyron Database File,,,,,,,,,
 PCSAFT Like Parameters,,,,,,,,,
-species,DIPPR Number,Mw,m,c,vol,epsilon,n_H,n_e,source
+species,DIPPR Number,Mw,segment,c,vol,epsilon,n_H,n_e,source
 nitrogen,,,1,3,19.457,123.53,0,0,0
 argon,,,1,0,16.29,150.86,0,0,
 carbon monoxide,,,1.221,4.2,15.776,111.97,0,0,

--- a/database/SAFT/LJSAFT/LJSAFT_like.csv
+++ b/database/SAFT/LJSAFT/LJSAFT_like.csv
@@ -1,6 +1,6 @@
 Clapeyron Database File,,,,,,,
 LJSAFT Like Parameters,,,,,,,
-species,DIPPR Number,m,b,T_tilde,n_H,n_e,source
+species,DIPPR Number,segment,b,T_tilde,n_H,n_e,source
 methane,,1.0569,0.02953,144.4354,0,0,
 ethane,,1.6025,0.02777,190.7260,0,0,
 propane,,2.0040,0.02949,209.3365,0,0,

--- a/database/SAFT/PCSAFT/PCSAFT_like.csv
+++ b/database/SAFT/PCSAFT/PCSAFT_like.csv
@@ -1,6 +1,6 @@
 Clapeyron Database File,,,,,,,,
 PCSAFT Like Parameters,,,,,,,,
-species,DIPPR Number,Mw,m,sigma,epsilon,n_H,n_e,source
+species,DIPPR Number,Mw,segment,sigma,epsilon,n_H,n_e,source
 methane,1,16.04,1,3.7039,150.03,0,0,10.1021/ie0003887
 ethane,2,30.07,1.6069,3.5206,191.42,0,0,10.1021/ie0003887
 propane,3,44.1,2.002,3.6184,208.11,0,0,10.1021/ie0003887

--- a/database/SAFT/PCSAFT/sPCSAFT/sPCSAFT_like.csv
+++ b/database/SAFT/PCSAFT/sPCSAFT/sPCSAFT_like.csv
@@ -1,6 +1,6 @@
 Clapeyron Database File,,,,,,,,
 sPCSAFT Like Parameters,,,,,,,,
-species,DIPPR Number,Mw,m,sigma,epsilon,n_H,n_e,source
+species,DIPPR Number,Mw,segment,sigma,epsilon,n_H,n_e,source
 methane,1,16.04,1,3.7039,150.03,0,0,10.1021/ie0003887
 ethane,2,30.07,1.6069,3.5206,191.42,0,0,10.1021/ie0003887
 propane,3,44.1,2.002,3.6184,208.11,0,0,10.1021/ie0003887

--- a/database/SAFT/SAFTVRMie/SAFTVRMie_like.csv
+++ b/database/SAFT/SAFTVRMie/SAFTVRMie_like.csv
@@ -1,6 +1,6 @@
 Clapeyron Database File,,,,,,,,,,
 SAFTVRMie Like Parameters,,,,,,,,,,
-species,DIPPR Number,Mw,m,sigma,epsilon,lambda_r,lambda_a,n_H,n_e,source
+species,DIPPR Number,Mw,segment,sigma,epsilon,lambda_r,lambda_a,n_H,n_e,source
 methane,,16.04,1,3.737,152.58,12.504,6,0,0,10.1016/j.fluid.2015.12.044
 ethane,,30.07,1.4373,3.7257,206.12,12.4,6,0,0,10.1063/1.4819787
 propane,,44.1,1.6845,3.9056,239.89,13.006,6,0,0,10.1063/1.4819788

--- a/database/SAFT/SAFTVRQMie/SAFTVRQMie_like.csv
+++ b/database/SAFT/SAFTVRQMie/SAFTVRQMie_like.csv
@@ -1,6 +1,6 @@
 Clapeyron Database File,,,,,,,,,,
 SAFTVRQMie Like Parameters,,,,,,,,,,
-species,DIPPR Number,Mw,m,sigma,epsilon,lambda_r,lambda_a,n_H,n_e,source
+species,DIPPR Number,Mw,segment,sigma,epsilon,lambda_r,lambda_a,n_H,n_e,source
 hydrogen,,2.01588,1,2.9195,55.729,20.0,6.0,0,0,
 deuterium,,4.0282035556,1,2.9897,36.913,12,6,0,0,
 helium,,4.002602,1,2.549,10.952,13,6,0,0,

--- a/database/SAFT/SAFTVRSW/SAFTVRSW_like.csv
+++ b/database/SAFT/SAFTVRSW/SAFTVRSW_like.csv
@@ -1,6 +1,6 @@
 Clapeyron database,,,,,,,,,
 SAFTVRSW Like Parameters,,,,,,,,,
-species,DIPPR Number,Mw,m,sigma,epsilon,lambda,n_e,n_H,source
+species,DIPPR Number,Mw,segment,sigma,epsilon,lambda,n_e,n_H,source
 methane,,16,1,4.069,157.4,1.444,0,0,
 ethane,,,1.33,4.233,224.8,1.449,0,0,
 propane,,,1.67,4.363,249.3,1.452,0,0,

--- a/database/SAFT/ogSAFT/ogSAFT_like.csv
+++ b/database/SAFT/ogSAFT/ogSAFT_like.csv
@@ -1,6 +1,6 @@
 Clapeyron Database File,,,,,,,,
 ogSAFT Like Parameters,,,,,,,,
-species,DIPPR Number,Mw,m,sigma,epsilon,n_e,n_H,source
+species,DIPPR Number,Mw,segment,sigma,epsilon,n_e,n_H,source
 water,,18,0.982,2.985,433.91,2,2,
 butane,,1,2.163,3.784,214.00,0,0,
 hexane,,1,2.739,3.911,230.03,0,0,

--- a/database/SAFT/sCKSAFT/sCKSAFT_like.csv
+++ b/database/SAFT/sCKSAFT/sCKSAFT_like.csv
@@ -1,6 +1,6 @@
 Clapeyron Database File,,,,,,,,
 sCKSAFT Like Parameters,,,,,,,,
-species,DIPPR Number,Mw,m,vol,epsilon,n_H,n_e,source
+species,DIPPR Number,Mw,segment,vol,epsilon,n_H,n_e,source
 ethane,,,2.022,16.236,90.529,0,0,
 propane,,,2.735,16.507,92.571,0,0,
 butane,,,2.962,19.263,102.823,0,0,

--- a/database/SAFT/softSAFT/softSAFT_like.csv
+++ b/database/SAFT/softSAFT/softSAFT_like.csv
@@ -1,6 +1,6 @@
 Clapeyron Database File,,,,,,,
 softSAFT Like Parameters,,,,,,,
-species,DIPPR Number,m,sigma,epsilon,n_H,n_e,source
+species,DIPPR Number,segment,sigma,epsilon,n_H,n_e,source
 methane,,1,3.728,147.2,0,0,
 ethane,,1.392,3.756,202.5,0,0,
 propane,,1.776,3.811,219.5,0,0,

--- a/database/cubic/QCPR/QCPR_critical.csv
+++ b/database/cubic/QCPR/QCPR_critical.csv
@@ -1,6 +1,6 @@
 Clapeyron Database File,,,,,,
 Critical QCPR Like Parameters,,,,,,
-species,Mw,Tc,pc
+species,Mw,Tc,Pc
 hydrogen,2.01588,33.19,12.964e5
 deuterium,4.0282035556,38.34,16.796e5
 helium,4.002602,5.1953,2.276e5

--- a/database/properties/critical.csv
+++ b/database/properties/critical.csv
@@ -1,6 +1,6 @@
 Clapeyron Database File,,,,,
 Critical Single Parameters,,,,,
-species,DIPPR Number,Tc,pc,vc,w
+species,DIPPR Number,Tc,Pc,Vc,acentricfactor
 Methane,74828,190.564,4.59E+06,9.92E-05,0.011
 Ethane,74840,305.32,4.85E+06,1.48E-04,0.098
 propane,74986,369.83,4.21E+06,2.03E-04,0.149

--- a/docs/src/properties/multi.md
+++ b/docs/src/properties/multi.md
@@ -56,8 +56,9 @@ Clapeyron.ActivityDewTemperature
 ```@docs
 Clapeyron.gibbs_duhem
 Clapeyron.isstable
-Clapeyron.mechanical_stability
-Clapeyron.diffusive_stability
+Clapeyron.VT_mechanical_stability
+Clapeyron.VT_diffusive_stability
+Clapeyron.VT_chemical_stability
 Clapeyron.tpd
 ```
 

--- a/docs/src/user_guide/custom_methods.md
+++ b/docs/src/user_guide/custom_methods.md
@@ -21,7 +21,7 @@ function Clapeyron.x0_sat_pure(model::PCSAFTModel,T,z=SA[1.0])
   Vlb = lb_volume(model,z)*one(T)
   
   # Relative to the lower bound, define your initial guesses. We log10 the results as our solvers solve for the log10 of the volume.
-  return log10.([Vlb*1.5,Vlb*100])
+  return Vlb*1.5,Vlb*100
 end
 ```
 

--- a/docs/src/user_guide/custom_model.md
+++ b/docs/src/user_guide/custom_model.md
@@ -108,7 +108,7 @@ function PCSAFT(components; idealmodel=BasicIdeal, userlocations=String[], ideal
     params,sites = getparams(components; userlocations=userlocations, verbose=verbose)
   
     # For clarity, we assign the contents of the returned dict to their own variables.
-    segment = params["m"]
+    segment = params["segment"]
     k = get(params,"k",nothing) #if k is not provided, it will be not be considered
     Mw = params["Mw"]
     # Here, we modify the values of the sigma parameter first.

--- a/src/methods/initial_guess.jl
+++ b/src/methods/initial_guess.jl
@@ -126,7 +126,7 @@ antoine_coef(model) = nothing
 """
     x0_sat_pure(model::EoSModel,T,z=SA[1.0])
 
-Returns a 2-tuple corresponding to `(log10(Vₗ),log10(Vᵥ))`, where `Vₗ` and `Vᵥ` are the liquid and vapor initial guesses.
+Returns a 2-tuple corresponding to `(Vₗ,Vᵥ)`, where `Vₗ` and `Vᵥ` are the liquid and vapor initial guesses.
 
 Used in [`saturation_pressure`](@ref) methods that require initial volume guesses.
 
@@ -182,7 +182,7 @@ function x0_sat_pure(model,T,z=SA[1.0])
         #old strategy
         x0l = 4*lb_v
         x0v = -2*B + 2*lb_v
-        return (log10(x0l),log10(x0v))
+        return (x0l,x0v)
     end
     Δsqrt = sqrt(Δ)
     b1 = 0.5*(-_b + Δsqrt)
@@ -207,7 +207,7 @@ function x0_sat_pure(model,T,z=SA[1.0])
     if Tr >= 1
         x0l = 4*lb_v
         x0v = -2*B + 2*lb_v
-        return (log10(x0l),log10(x0v))
+        return (x0l,x0v)
     end
     # if b1/b2 < -0.95, then T is near Tc.
     #if b<lb_v then we are in trouble
@@ -215,12 +215,12 @@ function x0_sat_pure(model,T,z=SA[1.0])
     if (b1/b2 < -0.95) | (b<lb_v) | (Tr>0.99)
         x0l = 4*lb_v
         x0v = -2*B #gas volume as high as possible
-        return (log10(x0l),log10(x0v))
+        return (x0l,x0v)
     end
     Vl0,Vv0 = vdw_x0_xat_pure(T,Tc,Pc,Vc)
     x0l = min(Vl0,vl)
     x0v = min(1e4*one(Vv0),Vv0) #cutoff volume
-    return (log10(x0l),log10(x0v))
+    return (x0l,x0v)
 end
 
 function vdw_x0_xat_pure(T,T_c,P_c,V_c)

--- a/src/methods/property_solvers/singlecomponent/saturation/AntoineSat.jl
+++ b/src/methods/property_solvers/singlecomponent/saturation/AntoineSat.jl
@@ -52,7 +52,7 @@ end
 
 #if a number is provided as initial point, it will instead proceed to solve directly
 function saturation_temperature(model::EoSModel, p, T0::Number)
-    sat = x0_sat_pure(model,T0) .|> exp10
+    sat = x0_sat_pure(model,T0)
     T0,vl,vv = promote(T0,sat[1],sat[2])
     return saturation_temperature_impl(model,p,AntoineSaturation(;T0,vl,vv))
 end
@@ -78,7 +78,7 @@ function x0_saturation_temperature(model::EoSModel,p,::AntoineSaturation)
     A,B,C = antoine_coef(model)
     lnp̄ = log(p / p_scale(model))
     T0 = T_scale(model)*(B/(A-lnp̄)-C)
-    Vl,Vv = x0_sat_pure(model,T0) .|> exp10
+    Vl,Vv = x0_sat_pure(model,T0)
     return (T0,Vl,Vv)
 end
 
@@ -89,17 +89,15 @@ function saturation_temperature_impl(model,p,method::AntoineSaturation)
     scales = scale_sat_pure(model)
     if isnothing(method.T0)
         T0,Vl,Vv = x0_saturation_temperature(model,p)
-        if isnothing(method.vl) && isnothing(method.vv)
-            Vl,Vv = log10(Vl),log10(Vv)
-        else
-            Vl,Vv = log10(method.vl),log10(method.vv)
+        if !(isnothing(method.vl) && isnothing(method.vv))
+            Vl,Vv = method.vl,method.vv
         end
     elseif isnothing(method.vl) && isnothing(method.vv)
-        Vl,Vv = x0_sat_pure(model,method.T0) #exp10
+        Vl,Vv = x0_sat_pure(model,method.T0)
+        Vl,Vv = method.vl,method.vv
         T0 = method.T0
     else
         T0,Vl,Vv = method.T0,method.vl,method.vv
-        Vl,Vv = log10(Vl),log10(Vv) 
     end
 
     T0,Vl,Vv = promote(T0,Vl,Vv)
@@ -130,7 +128,7 @@ function saturation_temperature_impl(model,p,method::AntoineSaturation)
         #log(p/p2)*R̄/ΔHvap = 1/T - 1/T2
         T3 = 1/(log(p2/p)*R̄/ΔHvap + 1/T2)
         (_,vl3,vv3) = saturation_pressure(model,T2,ChemPotVSaturation(crit_retry = false))
-        res,converged = try_sat_temp(model,p,T3,log10(vl3),log10(vv3),scales,method)
+        res,converged = try_sat_temp(model,p,T3,vl3,vv3,scales,method)
         converged && return res
     end
     #no luck here, we need to calculate the critical point
@@ -165,16 +163,17 @@ end
 
 function try_sat_temp(model,p,T0,Vl,Vv,scales,method::AntoineSaturation)
     if T0 isa Base.IEEEFloat # MVector does not work on non bits types, like BigFloat
-        v0 = MVector((T0,Vl,Vv))
+        v0 = MVector((T0,log(Vl),log(Vv)))
     else
-        v0 = SizedVector{3,typeof(T0)}((T0,Vl,Vv))
+        v0 = SizedVector{3,typeof(T0)}((T0,log(Vl),log(Vv)))
     end
-    f!(F,x) = Obj_Sat_Temp(model,F,x[1],exp10(x[2]),exp10(x[3]),p,scales,method)
+    #we solve volumes in a log scale
+    f!(F,x) = Obj_Sat_Temp(model,F,x[1],exp(x[2]),exp(x[3]),p,scales,method)
     r = Solvers.nlsolve(f!,v0, LineSearch(Newton()),NEqOptions(method),ForwardDiff.Chunk{3}())
     sol = Solvers.x_sol(r)
     T = sol[1]
-    Vl = exp10(sol[2])
-    Vv = exp10(sol[3])
+    Vl = exp(sol[2])
+    Vv = exp(sol[3])
     converged = check_valid_sat_pure(model,p,Vl,Vv,T)
     return (T,Vl,Vv),converged
 end

--- a/src/methods/property_solvers/singlecomponent/saturation/AntoineSat.jl
+++ b/src/methods/property_solvers/singlecomponent/saturation/AntoineSat.jl
@@ -94,12 +94,10 @@ function saturation_temperature_impl(model,p,method::AntoineSaturation)
         end
     elseif isnothing(method.vl) && isnothing(method.vv)
         Vl,Vv = x0_sat_pure(model,method.T0)
-        Vl,Vv = method.vl,method.vv
         T0 = method.T0
     else
         T0,Vl,Vv = method.T0,method.vl,method.vv
     end
-
     T0,Vl,Vv = promote(T0,Vl,Vv)
     nan = zero(T0)/zero(T0)
     fail = (nan,nan,nan)

--- a/src/methods/property_solvers/singlecomponent/saturation/ChemPotDensity.jl
+++ b/src/methods/property_solvers/singlecomponent/saturation/ChemPotDensity.jl
@@ -127,7 +127,7 @@ function ChemPotDensitySaturation(;vl = nothing,
 end
 
 function saturation_pressure_impl(model::EoSModel, T, method::ChemPotDensitySaturation{Nothing})
-    x0 = x0_sat_pure(model,T) .|> exp10
+    x0 = x0_sat_pure(model,T)
     vl,vv = x0
     method = ChemPotDensitySaturation(;vl,vv,method.crit)
     return saturation_pressure_impl(model,T,method)

--- a/src/methods/stability.jl
+++ b/src/methods/stability.jl
@@ -10,15 +10,15 @@ Checks:
 """
 function isstable(model,V,T,z)
     stable = true
-    if !mechanical_stability(model,V,T,z)
+    if !VT_mechanical_stability(model,V,T,z)
         @warn "StabilityWarning: Phase is mechanically unstable"
         stable = false
     end
-    if !diffusive_stability(model,V,T,z)
+    if !VT_diffusive_stability(model,V,T,z)
         @warn "StabilityWarning: Phase is diffusively unstable"
         stable = false
     end
-    if !chemical_stability(model,V,T,z)
+    if !VT_chemical_stability(model,V,T,z)
         @warn "StabilityWarning: Phase is chemically unstable"
         stable = false
     end
@@ -26,22 +26,22 @@ function isstable(model,V,T,z)
 end
 
 """
-    mechanical_stability(model,V,T,z)::Bool
+    VT_mechanical_stability(model,V,T,z)::Bool
 
 Performs a mechanical stability for a (V,T,z) pair, returns `true/false`.
 Checks if isothermal compressibility is not negative. 
 """
-function mechanical_stability(model,V,T,z)
+function VT_mechanical_stability(model,V,T,z)
     return VT_isothermal_compressibility(model,V,T,z) >= 0
 end
 
 """
-    diffusive_stability(model,V,T,z)::Bool
+    VT_diffusive_stability(model,V,T,z)::Bool
 
 Performs a diffusive stability for a (V,T,z) pair, returns `true/false`.
 Checks if all eigenvalues of `∂²A/∂n²` are positive.
 """
-function diffusive_stability(model,V,T,z)
+function VT_diffusive_stability(model,V,T,z)
     isone(length(model)) && return true
     A(x) = eos(model,V,T,x)
     Hf = ForwardDiff.hessian(A,z)
@@ -69,11 +69,11 @@ function gibbs_duhem(model,V,T,z=SA[1.0])
 end
 
 """
-    chemical_stability(model,V,T,z)::Bool
+    VT_chemical_stability(model,V,T,z)::Bool
 
 Performs a chemical stability check using the tangent plane distance criterion, starting with the wilson correlation for K-values.
 """
-function chemical_stability(model::EoSModel,V,T,z)
+function VT_chemical_stability(model::EoSModel,V,T,z)
     # Generate vapourlike and liquidlike initial guesses
     # Currently using Wilson correlation
 
@@ -123,5 +123,5 @@ function tangent_plane_distance(model,p,T,z,phase,w)
 end
 
 export isstable
-export mechanical_stability, diffusive_stability,chemical_stability
+export VT_mechanical_stability, VT_diffusive_stability,VT_chemical_stability
 export gibbs_duhem

--- a/src/models/Activity/Wilson/Wilson.jl
+++ b/src/models/Activity/Wilson/Wilson.jl
@@ -57,7 +57,7 @@ function Wilson(components::Vector{String};
     Tc        = params["Tc"]
     pc        = params["pc"]
     Mw        = params["Mw"]
-    ZRA       = SingleParam(params["w"],"acentric factor")
+    ZRA       = params["acentricfactor"]
     ZRA.values .*= -0.08775
     ZRA.values .+= 0.29056
     

--- a/src/models/Activity/Wilson/Wilson.jl
+++ b/src/models/Activity/Wilson/Wilson.jl
@@ -55,7 +55,7 @@ function Wilson(components::Vector{String};
     params = getparams(components, ["properties/critical.csv", "properties/molarmass.csv","Activity/Wilson/Wilson_unlike.csv"]; userlocations=userlocations, asymmetricparams=["g"], ignore_missing_singleparams=["g"], verbose=verbose)
     g  = params["g"]
     Tc        = params["Tc"]
-    pc        = params["pc"]
+    pc        = params["Pc"]
     Mw        = params["Mw"]
     ZRA       = params["acentricfactor"]
     ZRA.values .*= -0.08775

--- a/src/models/AnalyticalSLV/AnalyticalSLV.jl
+++ b/src/models/AnalyticalSLV/AnalyticalSLV.jl
@@ -41,7 +41,7 @@ function AnalyticalSLV(components;
     
     Mw = params["Mw"]
     Tc = params["Tc"]
-    Pc = params["pc"]
+    Pc = params["Pc"]
     Vc = params["Vc"]
 
     a0 = params["a0"]

--- a/src/models/AnalyticalSLV/AnalyticalSLV.jl
+++ b/src/models/AnalyticalSLV/AnalyticalSLV.jl
@@ -42,7 +42,7 @@ function AnalyticalSLV(components;
     Mw = params["Mw"]
     Tc = params["Tc"]
     Pc = params["pc"]
-    Vc = params["vc"]
+    Vc = params["Vc"]
 
     a0 = params["a0"]
     a1 = params["a1"]

--- a/src/models/CompositeModel/LiquidVolumeModel/COSTALD/costald.jl
+++ b/src/models/CompositeModel/LiquidVolumeModel/COSTALD/costald.jl
@@ -12,7 +12,7 @@ end
 function COSTALD(components::Vector{String}; userlocations::Vector{String}=String[], verbose::Bool=false)
     params = getparams(components, ["properties/critical.csv"]; userlocations=userlocations, verbose=verbose)
     Tc = params["Tc"]
-    Vc = params["vc"]
+    Vc = params["Vc"]
     acentricfactor = params["acentricfactor"]
     packagedparams = COSTALDParam(Tc,Vc,acentricfactor)
     model = COSTALD(packagedparams;verbose)

--- a/src/models/CompositeModel/LiquidVolumeModel/COSTALD/costald.jl
+++ b/src/models/CompositeModel/LiquidVolumeModel/COSTALD/costald.jl
@@ -13,7 +13,7 @@ function COSTALD(components::Vector{String}; userlocations::Vector{String}=Strin
     params = getparams(components, ["properties/critical.csv"]; userlocations=userlocations, verbose=verbose)
     Tc = params["Tc"]
     Vc = params["vc"]
-    acentricfactor = SingleParam(params["w"],"acentric factor")
+    acentricfactor = params["acentricfactor"]
     packagedparams = COSTALDParam(Tc,Vc,acentricfactor)
     model = COSTALD(packagedparams;verbose)
     return model

--- a/src/models/CompositeModel/LiquidVolumeModel/Rackett/RackettLiquid.jl
+++ b/src/models/CompositeModel/LiquidVolumeModel/Rackett/RackettLiquid.jl
@@ -11,7 +11,7 @@ end
 
 function RackettLiquid(components::Vector{String}; userlocations::Vector{String}=String[], verbose::Bool=false)
     params = getparams(components, ["properties/critical.csv"]; userlocations=userlocations, verbose=verbose)
-    acentricfactor = SingleParam(params["w"],"acentric factor")
+    acentricfactor = params["acentricfactor"]
     Tc = params["Tc"]
     Pc = params["pc"]
     vc = params["vc"]
@@ -74,7 +74,7 @@ end
 
 function YamadaGunnLiquid(components::Vector{String}; userlocations::Vector{String}=String[], verbose::Bool=false)
     params = getparams(components, ["properties/critical.csv"]; userlocations=userlocations, verbose=verbose)
-    acentricfactor = SingleParam(params["w"],"acentric factor")
+    acentricfactor = params["acentricfactor"]
     Tc = params["Tc"]
     Pc = params["pc"]
     _zc = 0.29056 .- 0.08775 .* acentricfactor.values

--- a/src/models/CompositeModel/LiquidVolumeModel/Rackett/RackettLiquid.jl
+++ b/src/models/CompositeModel/LiquidVolumeModel/Rackett/RackettLiquid.jl
@@ -14,7 +14,7 @@ function RackettLiquid(components::Vector{String}; userlocations::Vector{String}
     acentricfactor = params["acentricfactor"]
     Tc = params["Tc"]
     Pc = params["pc"]
-    vc = params["vc"]
+    vc = params["Vc"]
     _zc = Pc.values .* vc.values ./ (R̄ .* Tc.values)
     Zc = SingleParam("Critical Compressibility factor",components,_zc) 
     packagedparams = RackettLiquidParam(Tc,Pc,Zc)

--- a/src/models/CompositeModel/LiquidVolumeModel/Rackett/RackettLiquid.jl
+++ b/src/models/CompositeModel/LiquidVolumeModel/Rackett/RackettLiquid.jl
@@ -13,7 +13,7 @@ function RackettLiquid(components::Vector{String}; userlocations::Vector{String}
     params = getparams(components, ["properties/critical.csv"]; userlocations=userlocations, verbose=verbose)
     acentricfactor = params["acentricfactor"]
     Tc = params["Tc"]
-    Pc = params["pc"]
+    Pc = params["Pc"]
     vc = params["Vc"]
     _zc = Pc.values .* vc.values ./ (R̄ .* Tc.values)
     Zc = SingleParam("Critical Compressibility factor",components,_zc) 
@@ -76,7 +76,7 @@ function YamadaGunnLiquid(components::Vector{String}; userlocations::Vector{Stri
     params = getparams(components, ["properties/critical.csv"]; userlocations=userlocations, verbose=verbose)
     acentricfactor = params["acentricfactor"]
     Tc = params["Tc"]
-    Pc = params["pc"]
+    Pc = params["Pc"]
     _zc = 0.29056 .- 0.08775 .* acentricfactor.values
     Zc = SingleParam("Critical Compressibility factor",components,_zc) 
     packagedparams = RackettLiquidParam(Tc,Pc,Zc)

--- a/src/models/CompositeModel/SaturationModel/DIPPR101Sat/DIPPR101Sat.jl
+++ b/src/models/CompositeModel/SaturationModel/DIPPR101Sat/DIPPR101Sat.jl
@@ -24,7 +24,7 @@ end
 ## Input Parameters
 
 - `Tc`: Single Parameter (`Float64`) - Critical Temperature `[K]`
-- `pc`: Single Parameter (`Float64`) - Critical Pressure `[Pa]`
+- `Pc`: Single Parameter (`Float64`) - Critical Pressure `[Pa]`
 - `A`: Single Parameter (`Float64`)
 - `B`: Single Parameter (`Float64`)
 - `C`: Single Parameter (`Float64`)
@@ -61,7 +61,7 @@ DIPPR101Sat
 function DIPPR101Sat(components::Vector{String}; userlocations::Vector{String}=String[], verbose::Bool=false)
     params = getparams(components, ["properties/critical.csv","Correlations/saturation_correlations/dippr101_like.csv"]; userlocations=userlocations, verbose=verbose)
     Tc = params["Tc"]
-    Pc = params["pc"]
+    Pc = params["Pc"]
     A = params["A"]
     B = params["B"]
     C = params["C"]

--- a/src/models/CompositeModel/SaturationModel/LeeKeslerSat/LeeKeslerSat.jl
+++ b/src/models/CompositeModel/SaturationModel/LeeKeslerSat/LeeKeslerSat.jl
@@ -18,7 +18,7 @@ end
 ## Input Parameters
 
 - `Tc`: Single Parameter (`Float64`) - Critical Temperature `[K]`
-- `pc`: Single Parameter (`Float64`) - Critical Pressure `[Pa]`
+- `Pc`: Single Parameter (`Float64`) - Critical Pressure `[Pa]`
 - `acentricfactor`: Single Parameter (`Float64`) - acentric factor
 
 ## Description
@@ -41,7 +41,7 @@ function LeeKeslerSat(components::Vector{String}; userlocations::Vector{String}=
     params = getparams(components, ["properties/critical.csv"]; userlocations=userlocations, verbose=verbose)
     acentricfactor = params["acentricfactor"]
     Tc = params["Tc"]
-    Pc = params["pc"]
+    Pc = params["Pc"]
     packagedparams = LeeKeslerSatParam(Tc,Pc,acentricfactor)
     model = LeeKeslerSat(packagedparams, verbose=verbose)
     return model

--- a/src/models/CompositeModel/SaturationModel/LeeKeslerSat/LeeKeslerSat.jl
+++ b/src/models/CompositeModel/SaturationModel/LeeKeslerSat/LeeKeslerSat.jl
@@ -19,12 +19,6 @@ end
 
 - `Tc`: Single Parameter (`Float64`) - Critical Temperature `[K]`
 - `pc`: Single Parameter (`Float64`) - Critical Pressure `[Pa]`
-- `w`: Single Parameter (`Float64`) - acentric factor
-
-## Model Parameters
-
-- `Tc`: Single Parameter (`Float64`) - Critical Temperature `[K]`
-- `pc`: Single Parameter (`Float64`) - Critical Pressure `[Pa]`
 - `acentricfactor`: Single Parameter (`Float64`) - acentric factor
 
 ## Description
@@ -45,7 +39,7 @@ LeeKeslerSat
 
 function LeeKeslerSat(components::Vector{String}; userlocations::Vector{String}=String[], verbose::Bool=false)
     params = getparams(components, ["properties/critical.csv"]; userlocations=userlocations, verbose=verbose)
-    acentricfactor = SingleParam(params["w"],"acentric factor")
+    acentricfactor = params["acentricfactor"]
     Tc = params["Tc"]
     Pc = params["pc"]
     packagedparams = LeeKeslerSatParam(Tc,Pc,acentricfactor)

--- a/src/models/ECS/ECS.jl
+++ b/src/models/ECS/ECS.jl
@@ -173,11 +173,7 @@ function x0_sat_pure(model::ECS,T,z = SA[1.0])
     f,h = shape_factors(model,zero(T),T) 
     T0 = T/f
     v0l,v0v = x0_sat_pure(model.model_ref,T0)
-    lh = log10(h)
-    v0l = v0l + lh
-    v0v = v0v + lh
-    v0 = (v0l,v0v) 
-    return v0
+    return (v0l*h,v0v*h) 
 end
 
 function split_model(model::ECS,subset=nothing)

--- a/src/models/EmpiricHelmholtz/IAPWS95/IAPWS95.jl
+++ b/src/models/EmpiricHelmholtz/IAPWS95/IAPWS95.jl
@@ -290,8 +290,7 @@ function x0_sat_pure(model::IAPWS95,T)
     else
         vl = saturated_water_liquid(T)
         vg = saturated_water_vapor(T)
-        x0  = (vl,vg)
-    return log10.(x0)
+        return (vl,vg)
     end
 end
 

--- a/src/models/EmpiricHelmholtz/LJRef/LJRef.jl
+++ b/src/models/EmpiricHelmholtz/LJRef/LJRef.jl
@@ -391,7 +391,7 @@ function x0_sat_pure_lj(model,T)
     Tc = 1.32*T_scale(model)
     ρl =  ljref_rholsat(T/Tc)/(m̄*N_A*σ3)
     ρv =  ljref_rhovsat(T/Tc)/(m̄*N_A*σ3)
-    return (log10(1/ρl),log10(1/ρv))
+    return (1/ρl,1/ρv)
 end
 
 x0_sat_pure(model::LJRef,T) = x0_sat_pure_lj(model,T)

--- a/src/models/EmpiricHelmholtz/LJRef/LJRef.jl
+++ b/src/models/EmpiricHelmholtz/LJRef/LJRef.jl
@@ -202,7 +202,7 @@ function LJRef(components;
     k = get(params,"k",nothing)
     sigma = sigma_LorentzBerthelot(params["sigma"])
     epsilon = epsilon_LorentzBerthelot(params["epsilon"], k)
-    segment = params["m"]
+    segment = params["segment"]
     params = LJRefParam(epsilon,sigma,segment,Mw)
     consts = LJRefConsts()
     references = ["10.1063/1.4945000"]

--- a/src/models/EmpiricHelmholtz/MultiFluid/equations.jl
+++ b/src/models/EmpiricHelmholtz/MultiFluid/equations.jl
@@ -237,7 +237,7 @@ function x0_sat_pure(model::MultiFluidModel,T)
     T0 = 369.89*T/Ts
     vl = (1.0/_propaneref_rholsat(T0))*h
     vv = (1.0/_propaneref_rhovsat(T0))*h
-    return (log10(vl),log10(vv)) 
+    return (vl,vv) 
 end
 
 #Corresponding States

--- a/src/models/EmpiricHelmholtz/PropaneRef.jl
+++ b/src/models/EmpiricHelmholtz/PropaneRef.jl
@@ -216,9 +216,9 @@ function Base.show(io::IO,mime::MIME"text/plain",model::PropaneRef)
 end
 
 function x0_sat_pure(model::PropaneRef,T,z=SA[1.0])
-    log10vv = log10(1.0/_propaneref_rhovsat(T))
-    log10vl = log10(1.0/_propaneref_rholsat(T))
-    return (log10vl,log10vv)
+    vv = 1.0/_propaneref_rhovsat(T)
+    vl = 1.0/_propaneref_rholsat(T)
+    return (vl,vv)
 end
 
 function x0_volume_liquid(model::PropaneRef,T,z = SA[1.0])

--- a/src/models/PeTS/PeTS.jl
+++ b/src/models/PeTS/PeTS.jl
@@ -25,7 +25,7 @@ end
 
 ## Input parameters
 - `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g/mol]`
-- `m`: Single Parameter (`Float64`) - Number of segments (no units)
+- `segment`: Single Parameter (`Float64`) - Number of segments (no units)
 - `sigma`: Single Parameter (`Float64`) - Segment Diameter [`A°`]
 - `epsilon`: Single Parameter (`Float64`) - Reduced dispersion energy  `[K]`
 - `k`: Pair Parameter (`Float64`) (optional) - Binary Interaction Paramater (no units)
@@ -57,7 +57,7 @@ function PeTS(components;
     verbose=false)
     params,sites = getparams(components, ["SAFT/PCSAFT","properties/molarmass.csv"]; userlocations=userlocations, verbose=verbose)
     
-    segment = params["m"]
+    segment = params["segment"]
     k = get(params,"k",nothing)
     Mw = params["Mw"]
     params["sigma"].values .*= 1E-10

--- a/src/models/SAFT/BACKSAFT/BACKSAFT.jl
+++ b/src/models/SAFT/BACKSAFT/BACKSAFT.jl
@@ -24,7 +24,7 @@ export BACKSAFT
 
 ## Input parameters
 - `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g/mol]`
-- `m`: Single Parameter (`Float64`) - Number of segments (no units)
+- `segment`: Single Parameter (`Float64`) - Number of segments (no units)
 - `vol`: Single Parameter (`Float64`) - Segment Volume [`dm^3`]
 - `epsilon`: Single Parameter (`Float64`) - Reduced dispersion energy  `[K/mol]`
 - `k`: Pair Parameter (`Float64`) (optional) - Binary Interaction Paramater (no units)
@@ -59,7 +59,7 @@ function BACKSAFT(components;
     assoc_options = AssocOptions(), kwargs...)
 
     params = getparams(components, ["SAFT/BACKSAFT","properties/molarmass.csv"]; userlocations=userlocations, verbose=verbose)
-    segment = params["m"]
+    segment = params["segment"]
     c = params["c"]
     k = get(params,"k",nothing)
     alpha = params["alpha"]

--- a/src/models/SAFT/CKSAFT/CKSAFT.jl
+++ b/src/models/SAFT/CKSAFT/CKSAFT.jl
@@ -24,7 +24,7 @@ export CKSAFT
 
 ## Input parameters
 - `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g/mol]`
-- `m`: Single Parameter (`Float64`) - Number of segments (no units)
+- `segment`: Single Parameter (`Float64`) - Number of segments (no units)
 - `vol`: Single Parameter (`Float64`) - Segment Volume [`dm^3`]
 - `epsilon`: Single Parameter (`Float64`) - Reduced dispersion energy  `[K]`
 - `k`: Pair Parameter (`Float64`) (optional) - Binary Interaction Paramater (no units)
@@ -62,7 +62,7 @@ function CKSAFT(components;
     assoc_options = AssocOptions(), kwargs...)
 
     params,sites = getparams(components, ["SAFT/CKSAFT","properties/molarmass.csv"]; userlocations=userlocations, verbose=verbose)
-    segment = params["m"]
+    segment = params["segment"]
     c = params["c"]
     k = get(params,"k",nothing)
     sigma = params["vol"]

--- a/src/models/SAFT/CKSAFT/variants/sCKSAFT.jl
+++ b/src/models/SAFT/CKSAFT/variants/sCKSAFT.jl
@@ -23,7 +23,7 @@ export sCKSAFT
 
 ## Input parameters
 - `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g/mol]`
-- `m`: Single Parameter (`Float64`) - Number of segments (no units)
+- `segment`: Single Parameter (`Float64`) - Number of segments (no units)
 - `vol`: Single Parameter (`Float64`) - Segment Volume [`dm^3`]
 - `epsilon`: Single Parameter (`Float64`) - Reduced dispersion energy  `[K]`
 - `k`: Pair Parameter (`Float64`) (optional) - Binary Interaction Paramater (no units)
@@ -60,7 +60,7 @@ function sCKSAFT(components::Vector{String};
     assoc_options = AssocOptions(), kwargs...)
 
     params,sites = getparams(components, ["SAFT/sCKSAFT","properties/molarmass.csv"]; userlocations=userlocations, verbose=verbose)
-    segment = params["m"]
+    segment = params["segment"]
     k = get(params,"k",nothing)
     sigma = params["vol"]
     sigma.values .*= 6*0.74048/N_A/1e6/π

--- a/src/models/SAFT/CPA/CPA.jl
+++ b/src/models/SAFT/CPA/CPA.jl
@@ -43,7 +43,6 @@ end
 
 ## Input parameters
 - `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g/mol]`
-- `m`: Single Parameter (`Float64`) - Number of segments (no units)
 - `a`: Single Parameter (`Float64`) - Atraction parameter
 - `b`: Single Parameter (`Float64`) - Covolume
 - `c1`: Single Parameter (`Float64`) - α-function constant Parameter
@@ -53,7 +52,6 @@ end
 
 ## Model Parameters
 - `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g/mol]`
-- `m`: Single Parameter (`Float64`) - Number of segments (no units)
 - `a`: Pair Parameter (`Float64`) - Mixed Atraction Parameter
 - `b`: Pair Parameter (`Float64`) - Mixed Covolume
 - `c1`: Single Parameter (`Float64`) - α-function constant Parameter

--- a/src/models/SAFT/CPA/CPA.jl
+++ b/src/models/SAFT/CPA/CPA.jl
@@ -109,9 +109,9 @@ function CPA(components;
     init_translation = init_model(translation,components,translation_userlocations,verbose)
 
     if occursin("RK",string(cubicmodel))
-        cubicparams = RKParam(a, b, params["Tc"],params["pc"],Mw)
+        cubicparams = RKParam(a, b, params["Tc"],params["Pc"],Mw)
     elseif occursin("PR",string(cubicmodel))
-        cubicparams = PRParam(a, b, params["Tc"],params["pc"],Mw)
+        cubicparams = PRParam(a, b, params["Tc"],params["Pc"],Mw)
     end
 
     init_cubicmodel = cubicmodel(components,init_alpha,init_mixing,init_translation,cubicparams,init_idealmodel,String[])

--- a/src/models/SAFT/CPA/variants/sCPA.jl
+++ b/src/models/SAFT/CPA/variants/sCPA.jl
@@ -34,7 +34,7 @@ export sCPA
 
 ## Input parameters
 - `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g/mol]`
-- `m`: Single Parameter (`Float64`) - Number of segments (no units)
+- `segment`: Single Parameter (`Float64`) - Number of segments (no units)
 - `a`: Single Parameter (`Float64`) - Atraction Parameter
 - `b`: Single Parameter (`Float64`) - Covolume
 - `c1`: Single Parameter (`Float64`) - α-function constant Parameter
@@ -44,7 +44,7 @@ export sCPA
 
 ## Model Parameters
 - `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g/mol]`
-- `m`: Single Parameter (`Float64`) - Number of segments (no units)
+- `segment`: Single Parameter (`Float64`) - Number of segments (no units)
 - `a`: Pair Parameter (`Float64`) - Mixed Atraction Parameter
 - `b`: Pair Parameter (`Float64`) - Mixed Covolume
 - `c1`: Single Parameter (`Float64`) - α-function constant Parameter

--- a/src/models/SAFT/CPA/variants/sCPA.jl
+++ b/src/models/SAFT/CPA/variants/sCPA.jl
@@ -100,9 +100,9 @@ function sCPA(components;
     init_translation = init_model(translation,components,translation_userlocations,verbose)
 
     if occursin("RK",string(cubicmodel))
-        cubicparams = RKParam(a, b, params["Tc"],params["pc"],Mw)
+        cubicparams = RKParam(a, b, params["Tc"],params["Pc"],Mw)
     elseif occursin("PR",string(cubicmodel))
-        cubicparams = PRParam(a, b, params["Tc"],params["pc"],Mw)
+        cubicparams = PRParam(a, b, params["Tc"],params["Pc"],Mw)
     end
 
     init_cubicmodel = cubicmodel(components,init_alpha,init_mixing,init_translation,cubicparams,init_idealmodel,String[])

--- a/src/models/SAFT/LJSAFT/LJSAFT.jl
+++ b/src/models/SAFT/LJSAFT/LJSAFT.jl
@@ -22,7 +22,7 @@ abstract type LJSAFTModel <: SAFTModel end
 
 ## Input parameters
 - `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g/mol]`
-- `m`: Single Parameter (`Float64`) - Number of segments (no units)
+- `segment`: Single Parameter (`Float64`) - Number of segments (no units)
 - `b`: Single Parameter (`Float64`) - Segment Volume [`dm^3/mol`]
 - `T_tilde`: Single Parameter (`Float64`) - Lennard-Jones attraction parameter  `[K]`
 - `k`: Pair Parameter (`Float64`) (optional) - Binary Interaction Paramater for energy(no units)
@@ -58,7 +58,7 @@ function LJSAFT(components;
     verbose=false,
     assoc_options = AssocOptions(), kwargs...)
     params,sites = getparams(components, ["SAFT/LJSAFT","properties/molarmass.csv"]; userlocations=userlocations, verbose=verbose)
-    segment = params["m"]
+    segment = params["segment"]
 
     Mw = params["Mw"]
 

--- a/src/models/SAFT/PCSAFT/PCSAFT.jl
+++ b/src/models/SAFT/PCSAFT/PCSAFT.jl
@@ -20,7 +20,7 @@ abstract type PCSAFTModel <: SAFTModel end
     assoc_options = AssocOptions())
 ## Input parameters
 - `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g/mol]`
-- `m`: Single Parameter (`Float64`) - Number of segments (no units)
+- `segment`: Single Parameter (`Float64`) - Number of segments (no units)
 - `sigma`: Single Parameter (`Float64`) - Segment Diameter [`A°`]
 - `epsilon`: Single Parameter (`Float64`) - Reduced dispersion energy  `[K]`
 - `k`: Pair Parameter (`Float64`) (optional) - Binary Interaction Paramater (no units)
@@ -51,7 +51,7 @@ function PCSAFT(components;
     verbose=false,
     assoc_options = AssocOptions())
     params,sites = getparams(components, ["SAFT/PCSAFT","properties/molarmass.csv"]; userlocations=userlocations, verbose=verbose)
-    segment = params["m"]
+    segment = params["segment"]
     k = get(params,"k",nothing)
     Mw = params["Mw"]
     params["sigma"].values .*= 1E-10

--- a/src/models/SAFT/PCSAFT/variants/GEPCSAFT.jl
+++ b/src/models/SAFT/PCSAFT/variants/GEPCSAFT.jl
@@ -26,7 +26,7 @@ end
 
 ## Input parameters
 - `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g/mol]`
-- `m`: Single Parameter (`Float64`) - Number of segments (no units)
+- `segment`: Single Parameter (`Float64`) - Number of segments (no units)
 - `sigma`: Single Parameter (`Float64`) - Segment Diameter [`A°`]
 - `epsilon`: Single Parameter (`Float64`) - Reduced dispersion energy  `[K]`
 - `k`: Pair Parameter (`Float64`) (optional) - Binary Interaction Paramater (no units)
@@ -64,7 +64,7 @@ function GEPCSAFT(components::Vector{String}; idealmodel=BasicIdeal,
     verbose=false)
 
     params,sites = getparams(components, ["SAFT/PCSAFT/PCSAFT_like.csv","SAFT/PCSAFT/PCSAFT_unlike.csv","SAFT/PCSAFT/PCSAFT_assoc.csv"]; userlocations=userlocations, verbose=verbose)
-    segment = params["m"]
+    segment = params["segment"]
     k = get(params,"k",nothing)
     Mw = params["Mw"]
     params["sigma"].values .*= 1E-10

--- a/src/models/SAFT/PCSAFT/variants/PharmaPCSAFT.jl
+++ b/src/models/SAFT/PCSAFT/variants/PharmaPCSAFT.jl
@@ -36,7 +36,7 @@ export pharmaPCSAFT
     assoc_options = AssocOptions())
 ## Input parameters
 - `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g/mol]`
-- `m`: Single Parameter (`Float64`) - Number of segments (no units)
+- `segment`: Single Parameter (`Float64`) - Number of segments (no units)
 - `sigma`: Single Parameter (`Float64`) - Segment Diameter [`A°`]
 - `epsilon`: Single Parameter (`Float64`) - Reduced dispersion energy  `[K]`
 - `k`: Pair Parameter (`Float64`) (optional) - Constant binary Interaction Paramater (no units)
@@ -76,7 +76,7 @@ function pharmaPCSAFT(components;
     ignore_missing_singleparams = ["kT"])
     
     water = SpecialComp(components,["water08"])
-    segment = params["m"]
+    segment = params["segment"]
     k0 = get(params,"k",nothing)
     n = length(components)
     k1 = get(params,"kT",PairParam("kT",components,zeros(n)))

--- a/src/models/SAFT/PCSAFT/variants/sPCSAFT.jl
+++ b/src/models/SAFT/PCSAFT/variants/sPCSAFT.jl
@@ -13,7 +13,7 @@ export sPCSAFT
     assoc_options = AssocOptions())
 ## Input parameters
 - `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g/mol]`
-- `m`: Single Parameter (`Float64`) - Number of segments (no units)
+- `segment`: Single Parameter (`Float64`) - Number of segments (no units)
 - `sigma`: Single Parameter (`Float64`) - Segment Diameter [`A°`]
 - `epsilon`: Single Parameter (`Float64`) - Reduced dispersion energy  `[K]`
 - `k`: Pair Parameter (`Float64`) (optional) - Binary Interaction Paramater (no units)
@@ -44,7 +44,7 @@ function sPCSAFT(components;
     
     params,sites = getparams(components, ["SAFT/PCSAFT", "SAFT/PCSAFT/sPCSAFT"]; userlocations=userlocations, verbose=verbose)
     
-    segment = params["m"]
+    segment = params["segment"]
     k = get(params,"k",nothing)
     Mw = params["Mw"]
     params["sigma"].values .*= 1E-10

--- a/src/models/SAFT/SAFTVRMie/SAFTVRMie.jl
+++ b/src/models/SAFT/SAFTVRMie/SAFTVRMie.jl
@@ -24,7 +24,7 @@ abstract type SAFTVRMieModel <: SAFTModel end
 
 ## Input parameters
 - `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g/mol]`
-- `m`: Single Parameter (`Float64`) - Number of segments (no units)
+- `segment`: Single Parameter (`Float64`) - Number of segments (no units)
 - `sigma`: Single Parameter (`Float64`) - Segment Diameter [`A°`]
 - `epsilon`: Single Parameter (`Float64`) - Reduced dispersion energy  `[K]`
 - `lambda_a`: Pair Parameter (`Float64`) - Atractive range parameter (no units)
@@ -67,7 +67,7 @@ function SAFTVRMie(components;
     params,sites = getparams(components, ["SAFT/SAFTVRMie", "properties/molarmass.csv"]; userlocations=userlocations, verbose=verbose)
 
     Mw = params["Mw"]
-    segment = params["m"]
+    segment = params["segment"]
     params["sigma"].values .*= 1E-10
     sigma = sigma_LorentzBerthelot(params["sigma"])
     epsilon = epsilon_HudsenMcCoubrey(params["epsilon"], sigma)

--- a/src/models/SAFT/SAFTVRMie/variants/SAFTVRQMie.jl
+++ b/src/models/SAFT/SAFTVRMie/variants/SAFTVRQMie.jl
@@ -22,7 +22,7 @@ abstract type SAFTVRQMieModel <: SAFTVRMieModel end
 
 ## Input parameters
 - `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g/mol]`
-- `m`: Single Parameter (`Float64`) - Number of segments (no units)
+- `segment`: Single Parameter (`Float64`) - Number of segments (no units)
 - `sigma`: Single Parameter (`Float64`) - Segment Diameter [`A°`]
 - `lambda_a`: Pair Parameter (`Float64`) - Atractive range parameter (no units)
 - `lambda_r`: Pair Parameter (`Float64`) - Repulsive range parameter (no units)
@@ -57,7 +57,7 @@ function SAFTVRQMie(components; idealmodel=BasicIdeal, userlocations=String[], i
     Mw .*= 1E-3
     mw_mix(mi,mj,k) = mix_powmean(mi,mj,k,-1) #mij = 0.5/(mi^-1 + mj^-1)
     Mw = kij_mix(mw_mix,Mw)
-    segment = params["m"]
+    segment = params["segment"]
     k = get(params,"k",nothing)
     l = get(params,"l",nothing)
     params["sigma"].values .*= 1E-10

--- a/src/models/SAFT/SAFTVRSW/SAFTVRSW.jl
+++ b/src/models/SAFT/SAFTVRSW/SAFTVRSW.jl
@@ -25,7 +25,7 @@ export SAFTVRSW
 
 ## Input parameters
 - `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g/mol]`
-- `m`: Single Parameter (`Float64`) - Number of segments (no units)
+- `segment`: Single Parameter (`Float64`) - Number of segments (no units)
 - `sigma`: Single Parameter (`Float64`) - Segment Diameter [`A°`]
 - `epsilon`: Single Parameter (`Float64`) - Reduced dispersion energy  `[K]`
 - `lambda`: Single Parameter (`Float64`) - Soft Well range parameter (no units)
@@ -63,7 +63,7 @@ function SAFTVRSW(components;
 
     params,sites = getparams(components, ["SAFT/SAFTVRSW","properties/molarmass.csv"]; userlocations=userlocations, verbose=verbose)
 
-    segment = params["m"]
+    segment = params["segment"]
     k = get(params,"k",nothing)
     Mw = params["Mw"]
     params["sigma"].values .*= 1E-10

--- a/src/models/SAFT/SAFTgammaMie/SAFTgammaMie.jl
+++ b/src/models/SAFT/SAFTgammaMie/SAFTgammaMie.jl
@@ -42,7 +42,7 @@ end
 
 ## Input parameters
 - `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g/mol]`
-- `m`: Single Parameter (`Float64`) - Number of segments (no units)
+- `segment`: Single Parameter (`Float64`) - Number of segments (no units)
 - `shapefactor`: Single Parameter (`Float64`) - Shape factor for segment (no units)
 - `sigma`: Single Parameter (`Float64`) - Segment Diameter [`A°`]
 - `epsilon`: Single Parameter (`Float64`) - Reduced dispersion energy  `[K]`

--- a/src/models/SAFT/ogSAFT/ogSAFT.jl
+++ b/src/models/SAFT/ogSAFT/ogSAFT.jl
@@ -22,7 +22,7 @@ abstract type ogSAFTModel <: SAFTModel end
 
 ## Input parameters
 - `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g/mol]`
-- `m`: Single Parameter (`Float64`) - Number of segments (no units)
+- `segment`: Single Parameter (`Float64`) - Number of segments (no units)
 - `sigma`: Single Parameter (`Float64`) - Segment Diameter [`A°`]
 - `epsilon`: Single Parameter (`Float64`) - Reduced dispersion energy  `[K]`
 - `k`: Pair Parameter (`Float64`) (optional) - Binary Interaction Paramater (no units)
@@ -60,7 +60,7 @@ function ogSAFT(components;
     assoc_options = AssocOptions(), kwargs...)
 
     params,sites = getparams(components, ["SAFT/ogSAFT","properties/molarmass.csv"]; userlocations=userlocations, verbose=verbose)
-    segment = params["m"]
+    segment = params["segment"]
     k = get(params,"k",nothing)
     params["sigma"].values .*= 1E-10
     sigma = sigma_LorentzBerthelot(params["sigma"])

--- a/src/models/SAFT/softSAFT/softSAFT.jl
+++ b/src/models/SAFT/softSAFT/softSAFT.jl
@@ -23,7 +23,7 @@ abstract type softSAFTModel <: SAFTModel end
 
 ## Input parameters
 - `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g/mol]`
-- `m`: Single Parameter (`Float64`) - Number of segments (no units)
+- `segment`: Single Parameter (`Float64`) - Number of segments (no units)
 - `sigma`: Single Parameter (`Float64`) - Segment Diameter [`A°`]
 - `epsilon`: Single Parameter (`Float64`) - Reduced dispersion energy  `[K]`
 - `k`: Pair Parameter (`Float64`) (optional) - Binary Interaction Paramater (no units)
@@ -62,7 +62,7 @@ function softSAFT(components;
 
     params,sites = getparams(components, ["SAFT/softSAFT","properties/molarmass.csv"]; userlocations=userlocations, verbose=verbose)
     
-    segment = params["m"]
+    segment = params["segment"]
     k = get(params,"k",nothing)
     params["sigma"].values .*= 1E-10
     sigma = sigma_LorentzBerthelot(params["sigma"])

--- a/src/models/SAFT/softSAFT/variants/softSAFT2016.jl
+++ b/src/models/SAFT/softSAFT/variants/softSAFT2016.jl
@@ -33,7 +33,7 @@ end
 
 ## Input parameters
 - `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g/mol]`
-- `m`: Single Parameter (`Float64`) - Number of segments (no units)
+- `segment`: Single Parameter (`Float64`) - Number of segments (no units)
 - `sigma`: Single Parameter (`Float64`) - Segment Diameter [`A°`]
 - `epsilon`: Single Parameter (`Float64`) - Reduced dispersion energy  `[K]`
 - `k`: Pair Parameter (`Float64`) (optional) - Binary Interaction Paramater (no units)
@@ -70,7 +70,7 @@ function softSAFT2016(components;
 
     params,sites = getparams(components, ["SAFT/softSAFT","properties/molarmass.csv"]; userlocations=userlocations, verbose=verbose)
     
-    segment = params["m"]
+    segment = params["segment"]
     k = get(params,"k",nothing)
     params["sigma"].values .*= 1E-10
     sigma = sigma_LorentzBerthelot(params["sigma"])

--- a/src/models/Virial/AbbottVirial/AbbottVirial.jl
+++ b/src/models/Virial/AbbottVirial/AbbottVirial.jl
@@ -55,7 +55,7 @@ function AbbottVirial(components;
     params = getparams(components,  ["properties/critical.csv", "properties/molarmass.csv"]; userlocations=userlocations, verbose=verbose)
     Mw = params["Mw"]
     Tc = params["Tc"]
-    Pc = params["pc"]
+    Pc = params["Pc"]
     acentricfactor = params["acentricfactor"]
     packagedparams = AbbottVirialParam(Tc,Pc,acentricfactor,Mw)
     references = String[]

--- a/src/models/Virial/AbbottVirial/AbbottVirial.jl
+++ b/src/models/Virial/AbbottVirial/AbbottVirial.jl
@@ -20,13 +20,6 @@ end
 
 - `Tc`: Single Parameter (`Float64`) - Critical Temperature `[K]`
 - `Pc`: Single Parameter (`Float64`) - Critical Pressure `[Pa]`
-- `w`: Single Parameter (`Float64`) - Acentric Factor
-- `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g/mol]`
-
-## Model Parameters
-
-- `Tc`: Single Parameter (`Float64`) - Critical Temperature `[K]`
-- `Pc`: Single Parameter (`Float64`) - Critical Pressure `[Pa]`
 - `acentricfactor`: Single Parameter (`Float64`) - Acentric Factor
 - `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g/mol]`
 
@@ -63,7 +56,7 @@ function AbbottVirial(components;
     Mw = params["Mw"]
     Tc = params["Tc"]
     Pc = params["pc"]
-    acentricfactor = params["w"]
+    acentricfactor = params["acentricfactor"]
     packagedparams = AbbottVirialParam(Tc,Pc,acentricfactor,Mw)
     references = String[]
     return AbbottVirial(packagedparams, idealmodel; ideal_userlocations, references, verbose)

--- a/src/models/Virial/TsonopoulosVirial/TsonopoulosVirial.jl
+++ b/src/models/Virial/TsonopoulosVirial/TsonopoulosVirial.jl
@@ -64,7 +64,7 @@ function TsonopoulosVirial(components;
     Mw = params["Mw"]
     Tc = params["Tc"]
     Pc = params["pc"]
-    acentricfactor = params["w"]
+    acentricfactor = params["acentricfactor"]
     packagedparams = TsonopoulosVirialParam(Tc,Pc,acentricfactor,Mw)
     references = String["10.1002/aic.690200209"]
     return TsonopoulosVirial(packagedparams, idealmodel; ideal_userlocations, references, verbose)

--- a/src/models/Virial/TsonopoulosVirial/TsonopoulosVirial.jl
+++ b/src/models/Virial/TsonopoulosVirial/TsonopoulosVirial.jl
@@ -63,7 +63,7 @@ function TsonopoulosVirial(components;
     params = getparams(components,["properties/critical.csv", "properties/molarmass.csv"]; userlocations=userlocations, verbose=verbose)
     Mw = params["Mw"]
     Tc = params["Tc"]
-    Pc = params["pc"]
+    Pc = params["Pc"]
     acentricfactor = params["acentricfactor"]
     packagedparams = TsonopoulosVirialParam(Tc,Pc,acentricfactor,Mw)
     references = String["10.1002/aic.690200209"]

--- a/src/models/cubic/KU/KU.jl
+++ b/src/models/cubic/KU/KU.jl
@@ -98,7 +98,7 @@ function KU(components::Vector{String}; idealmodel=BasicIdeal,
     params = getparams(components, ["properties/critical.csv", "properties/molarmass.csv","SAFT/PCSAFT/PCSAFT_unlike.csv"]; userlocations=userlocations, verbose=verbose)
     k  = get(params,"k",nothing)
     l = get(params,"l",nothing)
-    pc = params["pc"]
+    pc = params["Pc"]
     Mw = params["Mw"]
     Tc = params["Tc"]
     Vc = params["Vc"]

--- a/src/models/cubic/KU/KU.jl
+++ b/src/models/cubic/KU/KU.jl
@@ -101,7 +101,7 @@ function KU(components::Vector{String}; idealmodel=BasicIdeal,
     pc = params["pc"]
     Mw = params["Mw"]
     Tc = params["Tc"]
-    Vc = params["vc"]
+    Vc = params["Vc"]
     init_mixing = init_model(mixing,components,activity,mixing_userlocations,activity_userlocations,verbose)
     
     n = length(components)

--- a/src/models/cubic/PR/PR.jl
+++ b/src/models/cubic/PR/PR.jl
@@ -76,7 +76,7 @@ function PR(components::Vector{String}; idealmodel=BasicIdeal,
     params = getparams(components, ["properties/critical.csv", "properties/molarmass.csv","SAFT/PCSAFT/PCSAFT_unlike.csv"]; userlocations=userlocations, verbose=verbose)
     k  = get(params,"k",nothing)
     l = get(params,"l",nothing)
-    pc = params["pc"]
+    pc = params["Pc"]
     Mw = params["Mw"]
     Tc = params["Tc"]
     init_mixing = init_model(mixing,components,activity,mixing_userlocations,activity_userlocations,verbose)

--- a/src/models/cubic/PatelTeja/PatelTeja.jl
+++ b/src/models/cubic/PatelTeja/PatelTeja.jl
@@ -31,7 +31,7 @@ end
 ## Input parameters
 - `Tc`: Single Parameter (`Float64`) - Critical Temperature `[K]`
 - `Pc`: Single Parameter (`Float64`) - Critical Pressure `[Pa]`
-- `vc`: Single Parameter (`Float64`) - Critical Volume `[m3/mol]`
+- `Vc`: Single Parameter (`Float64`) - Critical Volume `[m3/mol]`
 - `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g/mol]`
 - `k`: Pair Parameter (`Float64`) (optional)
 - `l`: Pair Parameter (`Float64`) (optional)
@@ -89,7 +89,7 @@ function PatelTeja(components::Vector{String}; idealmodel=BasicIdeal,
     k  = get(params,"k",nothing)
     l = get(params,"l",nothing) 
     pc = params["pc"]
-    Vc = params["vc"]
+    Vc = params["Vc"]
     Mw = params["Mw"]
     Tc = params["Tc"]
     init_mixing = init_model(mixing,components,activity,mixing_userlocations,activity_userlocations,verbose)

--- a/src/models/cubic/PatelTeja/PatelTeja.jl
+++ b/src/models/cubic/PatelTeja/PatelTeja.jl
@@ -88,7 +88,7 @@ function PatelTeja(components::Vector{String}; idealmodel=BasicIdeal,
     params = getparams(components, ["properties/critical.csv", "properties/molarmass.csv","SAFT/PCSAFT/PCSAFT_unlike.csv"]; userlocations=userlocations, verbose=verbose)
     k  = get(params,"k",nothing)
     l = get(params,"l",nothing) 
-    pc = params["pc"]
+    pc = params["Pc"]
     Vc = params["Vc"]
     Mw = params["Mw"]
     Tc = params["Tc"]

--- a/src/models/cubic/PatelTeja/variants/PatelTejaValderrama.jl
+++ b/src/models/cubic/PatelTeja/variants/PatelTejaValderrama.jl
@@ -31,7 +31,7 @@ end
 ## Input parameters
 - `Tc`: Single Parameter (`Float64`) - Critical Temperature `[K]`
 - `Pc`: Single Parameter (`Float64`) - Critical Pressure `[Pa]`
-- `vc`: Single Parameter (`Float64`) - Critical Volume `[m3/mol]`
+- `Vc`: Single Parameter (`Float64`) - Critical Volume `[m3/mol]`
 - `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g/mol]`
 - `k`: Pair Parameter (`Float64`) (optional)
 - `l`: Pair Parameter (`Float64`) (optional)
@@ -91,7 +91,7 @@ function PTV(components::Vector{String}; idealmodel=BasicIdeal,
     k  = get(params,"k",nothing)
     l = get(params,"l",nothing)
     pc = params["pc"]
-    Vc = params["vc"]
+    Vc = params["Vc"]
     Mw = params["Mw"]
     Tc = params["Tc"]
     init_mixing = init_model(mixing,components,activity,mixing_userlocations,activity_userlocations,verbose)

--- a/src/models/cubic/PatelTeja/variants/PatelTejaValderrama.jl
+++ b/src/models/cubic/PatelTeja/variants/PatelTejaValderrama.jl
@@ -90,7 +90,7 @@ function PTV(components::Vector{String}; idealmodel=BasicIdeal,
     params = getparams(components, ["properties/critical.csv", "properties/molarmass.csv","SAFT/PCSAFT/PCSAFT_unlike.csv"]; userlocations=userlocations, verbose=verbose)
     k  = get(params,"k",nothing)
     l = get(params,"l",nothing)
-    pc = params["pc"]
+    pc = params["Pc"]
     Vc = params["Vc"]
     Mw = params["Mw"]
     Tc = params["Tc"]

--- a/src/models/cubic/RK/RK.jl
+++ b/src/models/cubic/RK/RK.jl
@@ -75,7 +75,7 @@ function RK(components::Vector{String}; idealmodel=BasicIdeal,
     params = getparams(components, ["properties/critical.csv", "properties/molarmass.csv","SAFT/PCSAFT/PCSAFT_unlike.csv"]; userlocations=userlocations, verbose=verbose)
     k  = get(params,"k",nothing)
     l = get(params,"l",nothing)
-    pc = params["pc"]
+    pc = params["Pc"]
     Mw = params["Mw"]
     Tc = params["Tc"]
     init_mixing = init_model(mixing,components,activity,mixing_userlocations,activity_userlocations,verbose)

--- a/src/models/cubic/RKPR/RKPR.jl
+++ b/src/models/cubic/RKPR/RKPR.jl
@@ -97,7 +97,7 @@ function RKPR(components::Vector{String}; idealmodel=BasicIdeal,
     params = getparams(components, ["properties/critical.csv", "properties/molarmass.csv","SAFT/PCSAFT/PCSAFT_unlike.csv"]; userlocations=userlocations, verbose=verbose)
     k  = get(params,"k",nothing)
     l = get(params,"l",nothing)
-    pc = params["pc"]
+    pc = params["Pc"]
     Vc = params["Vc"]
     Mw = params["Mw"]
     Tc = params["Tc"]

--- a/src/models/cubic/RKPR/RKPR.jl
+++ b/src/models/cubic/RKPR/RKPR.jl
@@ -31,7 +31,7 @@ export RKPR
 ## Input parameters
 - `Tc`: Single Parameter (`Float64`) - Critical Temperature `[K]`
 - `Pc`: Single Parameter (`Float64`) - Critical Pressure `[Pa]`
-- `vc`: Single Parameter (`Float64`) - Critical Volume `[m3/mol]`
+- `Vc`: Single Parameter (`Float64`) - Critical Volume `[m3/mol]`
 - `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g/mol]`
 - `k`: Pair Parameter (`Float64`) (optional)
 - `l`: Pair Parameter (`Float64`) (optional)
@@ -98,7 +98,7 @@ function RKPR(components::Vector{String}; idealmodel=BasicIdeal,
     k  = get(params,"k",nothing)
     l = get(params,"l",nothing)
     pc = params["pc"]
-    Vc = params["vc"]
+    Vc = params["Vc"]
     Mw = params["Mw"]
     Tc = params["Tc"]
     init_mixing = init_model(mixing,components,activity,mixing_userlocations,activity_userlocations,verbose)

--- a/src/models/cubic/alphas/BM.jl
+++ b/src/models/cubic/alphas/BM.jl
@@ -16,9 +16,6 @@ export BMAlpha
 
 ## Input Parameters
 
-- `w`: Single Parameter (`Float64`)
-
-## Model Parameters
 
 - `acentricfactor`: Single Parameter (`Float64`)
 
@@ -48,7 +45,7 @@ BMAlpha
 
 function BMAlpha(components::Vector{String}; userlocations::Vector{String}=String[], verbose::Bool=false)
     params = getparams(components, ["properties/critical.csv"]; userlocations=userlocations, verbose=verbose,ignore_headers = ONLY_ACENTRICFACTOR)
-    acentricfactor = SingleParam(params["w"],"acentric factor")
+    acentricfactor = params["acentricfactor"]
     packagedparams = BMAlphaParam(acentricfactor)
     model = BMAlpha(packagedparams, verbose=verbose)
     return model

--- a/src/models/cubic/alphas/KUAlpha.jl
+++ b/src/models/cubic/alphas/KUAlpha.jl
@@ -16,10 +16,6 @@ export KUAlpha
 
 ## Input Parameters
 
-- `w`: Single Parameter (`Float64`)
-
-## Model Parameters
-
 - `acentricfactor`: Single Parameter (`Float64`)
 
 ## Description
@@ -43,7 +39,7 @@ KUAlpha
 
 function KUAlpha(components::Vector{String}; userlocations::Vector{String}=String[], verbose::Bool=false)
     params = getparams(components, ["properties/critical.csv"]; userlocations=userlocations, verbose=verbose,ignore_headers = ONLY_ACENTRICFACTOR)
-    acentricfactor = SingleParam(params["w"],"acentric factor")
+    acentricfactor = params["acentricfactor"]
     packagedparams = KUAlphaParam(acentricfactor)
     model = KUAlpha(packagedparams, verbose=verbose)
     return model

--- a/src/models/cubic/alphas/MT.jl
+++ b/src/models/cubic/alphas/MT.jl
@@ -14,9 +14,6 @@ export MTAlpha
 
 ## Input Parameters
 
-- `w`: Single Parameter (`Float64`)
-
-## Model Parameters
 
 - `acentricfactor`: Single Parameter (`Float64`)
 
@@ -38,7 +35,7 @@ MTAlpha
 
 function MTAlpha(components::Vector{String}; userlocations::Vector{String}=String[], verbose::Bool=false)
     params = getparams(components, ["properties/critical.csv"]; userlocations=userlocations, verbose=verbose,ignore_headers = ONLY_ACENTRICFACTOR)
-    acentricfactor = SingleParam(params["w"],"acentric factor")
+    acentricfactor = params["acentricfactor"]
     packagedparams = MTAlphaParam(acentricfactor)
     model = MTAlpha(packagedparams, verbose=verbose)
     return model

--- a/src/models/cubic/alphas/PR78Alpha.jl
+++ b/src/models/cubic/alphas/PR78Alpha.jl
@@ -13,11 +13,12 @@ export PR78Alpha
     PR78Alpha(components::Vector{String};
     userlocations::Vector{String}=String[],
     verbose::Bool=false)
+
 ## Input Parameters
-- `w`: Single Parameter (`Float64`)
-## Model Parameters
 - `acentricfactor`: Single Parameter (`Float64`)
+
 ## Description
+
 Cubic alpha `(α(T))` model. Default for [`PR78`](@ref) and [`EPPR78`](@ref) EoS.
 ```
 αᵢ = (1+mᵢ(1-√(Trᵢ)))^2
@@ -32,7 +33,7 @@ PR78Alpha
 
 function PR78Alpha(components::Vector{String}; userlocations::Vector{String}=String[], verbose::Bool=false)
     params = getparams(components, ["properties/critical.csv"]; userlocations=userlocations, verbose=verbose,ignore_headers = ONLY_ACENTRICFACTOR)
-    acentricfactor = SingleParam(params["w"],"acentric factor")
+    acentricfactor = params["acentricfactor"]
     packagedparams = PR78AlphaParam(acentricfactor)
     model = PR78Alpha(packagedparams, verbose=verbose)
     return model

--- a/src/models/cubic/alphas/PRAlpha.jl
+++ b/src/models/cubic/alphas/PRAlpha.jl
@@ -11,10 +11,11 @@ export PRAlpha
     PRAlpha(components::Vector{String};
     userlocations::Vector{String}=String[],
     verbose::Bool=false)
+
 ## Input Parameters
-- `w`: Single Parameter (`Float64`)
-## Model Parameters
+
 - `acentricfactor`: Single Parameter (`Float64`)
+
 ## Description
 Cubic alpha `(α(T))` model. Default for [`PR`](@ref) EoS.
 ```
@@ -27,7 +28,7 @@ PRAlpha
 
 function PRAlpha(components::Vector{String}; userlocations::Vector{String}=String[], verbose::Bool=false)
     params = getparams(components, ["properties/critical.csv"]; userlocations=userlocations, verbose=verbose,ignore_headers = ONLY_ACENTRICFACTOR)
-    acentricfactor = SingleParam(params["w"],"acentric factor")
+    acentricfactor = params["acentricfactor"]
     packagedparams = PRAlphaParam(acentricfactor)
     model = PRAlpha(packagedparams, verbose=verbose)
     return model

--- a/src/models/cubic/alphas/PTVAlpha.jl
+++ b/src/models/cubic/alphas/PTVAlpha.jl
@@ -16,9 +16,6 @@ export PTVAlpha
 
 ## Input Parameters
 
-- `w`: Single Parameter (`Float64`)
-
-## Model Parameters
 
 - `acentricfactor`: Single Parameter (`Float64`)
 
@@ -35,7 +32,7 @@ PTVAlpha
 
 function PTVAlpha(components::Vector{String}; userlocations::Vector{String}=String[], verbose::Bool=false)
     params = getparams(components, ["properties/critical.csv"]; userlocations=userlocations, verbose=verbose,ignore_headers = ONLY_ACENTRICFACTOR)
-    acentricfactor = SingleParam(params["w"],"acentric factor")
+    acentricfactor = params["acentricfactor"]
     packagedparams = PTVAlphaParam(acentricfactor)
     model = PTVAlpha(packagedparams, verbose=verbose)
     return model

--- a/src/models/cubic/alphas/PatelTejaAlpha.jl
+++ b/src/models/cubic/alphas/PatelTejaAlpha.jl
@@ -14,10 +14,6 @@ export PatelTejaAlpha
 
 ## Input Parameters
 
-- `w`: Single Parameter (`Float64`)
-
-## Model Parameters
-
 - `acentricfactor`: Single Parameter (`Float64`)
 
 ## Description
@@ -34,7 +30,7 @@ PatelTejaAlpha
 
 function PatelTejaAlpha(components::Vector{String}; userlocations::Vector{String}=String[], verbose::Bool=false)
     params = getparams(components, ["properties/critical.csv"]; userlocations=userlocations, verbose=verbose,ignore_headers = ONLY_ACENTRICFACTOR)
-    acentricfactor = SingleParam(params["w"],"acentric factor")
+    acentricfactor = params["acentricfactor"]
     packagedparams = PatelTejaAlphaParam(acentricfactor)
     model = PatelTejaAlpha(packagedparams, verbose=verbose)
     return model

--- a/src/models/cubic/alphas/RKPRAlpha.jl
+++ b/src/models/cubic/alphas/RKPRAlpha.jl
@@ -16,9 +16,6 @@ export RKPRAlpha
 
 ## Input Parameters
 
-- `w`: Single Parameter (`Float64`)
-
-## Model Parameters
 
 - `acentricfactor`: Single Parameter (`Float64`)
 
@@ -35,7 +32,7 @@ RKPRAlpha
 
 function RKPRAlpha(components::Vector{String}; userlocations::Vector{String}=String[], verbose::Bool=false)
     params = getparams(components, ["properties/critical.csv"]; userlocations=userlocations, verbose=verbose,ignore_headers = ONLY_ACENTRICFACTOR)
-    acentricfactor = SingleParam(params["w"],"acentric factor")
+    acentricfactor = params["acentricfactor"]
     packagedparams = RKPRAlphaParam(acentricfactor)
     model = RKPRAlpha(packagedparams, verbose=verbose)
     return model

--- a/src/models/cubic/alphas/soave.jl
+++ b/src/models/cubic/alphas/soave.jl
@@ -16,9 +16,6 @@ export SoaveAlpha
 
 ## Input Parameters
 
-- `w`: Single Parameter (`Float64`)
-
-## Model Parameters
 
 - `acentricfactor`: Single Parameter (`Float64`)
 
@@ -37,7 +34,7 @@ SoaveAlpha
 
 function SoaveAlpha(components::Vector{String}; userlocations::Vector{String}=String[], verbose::Bool=false)
     params = getparams(components, ["properties/critical.csv"]; userlocations=userlocations, verbose=verbose,ignore_headers = ONLY_ACENTRICFACTOR)
-    acentricfactor = SingleParam(params["w"],"acentric factor")
+    acentricfactor = params["acentricfactor"]
     packagedparams = SoaveAlphaParam(acentricfactor)
     model = SoaveAlpha(packagedparams, verbose=verbose)
     return model

--- a/src/models/cubic/equations.jl
+++ b/src/models/cubic/equations.jl
@@ -335,7 +335,7 @@ function x0_sat_pure(model::ABCubicModel, T)
         _Δ = (pl0)/(vl_p0*dpdV)
         vl = vl_p0*exp(_Δ)
         vv = volume_virial(B,pl0,T) - c
-        return (log10(vl), log10(vv))
+        return (vl, vv)
     else 
         vc = zc*R̄*Tc/pc - c 
         pv0 = -0.25*R̄*T/B
@@ -351,9 +351,9 @@ function x0_sat_pure(model::ABCubicModel, T)
             vl = 0.5 * (vl + vlc)
             vv = 0.5 * (vv + vvc)
         end
-        return (log10(vl), log10(vv))
+        return (vl, vv)
     end
-    return (log10(vl), log10(vv))
+    return (vl, vv)
 end
 
 #=

--- a/src/models/cubic/mixing/Kay.jl
+++ b/src/models/cubic/mixing/Kay.jl
@@ -34,7 +34,7 @@ export KayRule
 
 function KayRule(components::Vector{String}; activity=nothing, userlocations::Vector{String}=String[], activity_userlocations::Vector{String}=String[], verbose::Bool=false, kwargs...)
     #params = getparams(components, ["properties/critical.csv"]; userlocations=userlocations, verbose=verbose)
-    #acentricfactor = SingleParam(params["w"],"acentric factor")
+    #acentricfactor = params["acentricfactor"]
     packagedparams = KayRuleParam()
     model = KayRule(packagedparams, verbose=verbose)
     return model

--- a/src/models/cubic/translation/Clausius.jl
+++ b/src/models/cubic/translation/Clausius.jl
@@ -37,7 +37,7 @@ ClausiusTranslation
 export ClausiusTranslation
 function ClausiusTranslation(components::Vector{String}; userlocations::Vector{String}=String[], verbose::Bool=false)
     params = getparams(components, ["properties/critical.csv"]; userlocations=userlocations, verbose=verbose)
-    Vc = params["vc"]
+    Vc = params["Vc"]
     packagedparams = ClausiusTranslationParam(Vc)
     model = ClausiusTranslation(packagedparams, verbose=verbose)
     return model

--- a/src/models/cubic/translation/MT.jl
+++ b/src/models/cubic/translation/MT.jl
@@ -17,10 +17,6 @@ MTTranslation <: MTTranslationModel
 
 ## Input Parameters
 
-- `w`: Single Parameter (`Float64`)
-
-## Model Parameters
-
 - `acentricfactor`: Single Parameter (`Float64`)
 
 ## Description
@@ -45,7 +41,7 @@ MTTranslation
 
 function MTTranslation(components::Vector{String}; userlocations::Vector{String}=String[], verbose::Bool=false)
     params = getparams(components, ["properties/critical.csv"]; userlocations=userlocations, verbose=verbose,ignore_headers = ONLY_ACENTRICFACTOR)
-    acentricfactor = SingleParam(params["w"],"acentric factor")
+    acentricfactor = params["acentricfactor"]
     packagedparams = MTTranslationParam(acentricfactor)
     model = MTTranslation(packagedparams, verbose=verbose)
     return model

--- a/src/models/cubic/translation/Peneloux.jl
+++ b/src/models/cubic/translation/Peneloux.jl
@@ -17,7 +17,7 @@ end
 
 ## Input Parameters
 
-- `vc`: Single Parameter (`Float64`) - Critical Volume `[m³/mol]`
+- `Vc`: Single Parameter (`Float64`) - Critical Volume `[m³/mol]`
 
 ## Model Parameters
 
@@ -44,7 +44,7 @@ PenelouxTranslation
 export PenelouxTranslation
 function PenelouxTranslation(components::Vector{String}; userlocations::Vector{String}=String[], verbose::Bool=false)
     params = getparams(components, ["properties/critical.csv"]; userlocations=userlocations, verbose=verbose,ignore_headers = ONLY_VC)
-    Vc = params["vc"]
+    Vc = params["Vc"]
     c = SingleParam("Volume shift",components,zeros(length(components)))
     c.ismissingvalues .= true
     packagedparams = PenelouxTranslationParam(Vc,c)

--- a/src/models/cubic/translation/Rackett.jl
+++ b/src/models/cubic/translation/Rackett.jl
@@ -16,7 +16,7 @@ end
 
 ## Input Parameters
 
-- `vc`: Single Parameter (`Float64`) - Critical Volume `[m³/mol]`
+- `Vc`: Single Parameter (`Float64`) - Critical Volume `[m³/mol]`
 
 ## Model Parameters
 
@@ -41,7 +41,7 @@ RackettTranslation
 export RackettTranslation
 function RackettTranslation(components::Vector{String}; userlocations::Vector{String}=String[], verbose::Bool=false)
     params = getparams(components, ["properties/critical.csv"]; userlocations=userlocations, verbose=verbose,ignore_headers = ONLY_VC)
-    Vc = params["vc"]
+    Vc = params["Vc"]
     c = SingleParam("Volume shift",components,zeros(length(components)))
     c.ismissingvalues .= true
     packagedparams = RackettTranslationParam(Vc,c)

--- a/src/models/cubic/vdW/variants/Berthelot.jl
+++ b/src/models/cubic/vdW/variants/Berthelot.jl
@@ -41,7 +41,7 @@ export Berthelot
 - `Tc`: Single Parameter (`Float64`) - Critical Temperature `[K]`
 - `Pc`: Single Parameter (`Float64`) - Critical Pressure `[Pa]`
 - `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g/mol]`
-- `vc`: Single Parameter (`Float64`) - Molar Volume `[m^3/mol]`
+- `Vc`: Single Parameter (`Float64`) - Molar Volume `[m^3/mol]`
 - `k`: Pair Parameter (`Float64`) (optional)
 
 ## Model Parameters
@@ -96,7 +96,7 @@ function Berthelot(components::Vector{String}; idealmodel=BasicIdeal,
     pc = params["pc"]
     Mw = params["Mw"]
     Tc = params["Tc"]
-    Vc = params["vc"]
+    Vc = params["Vc"]
     init_mixing = init_model(mixing,components,activity,mixing_userlocations,activity_userlocations,verbose)
     a = PairParam("a",components,zeros(length(components)))
     b = PairParam("b",components,zeros(length(components)))

--- a/src/models/cubic/vdW/variants/Berthelot.jl
+++ b/src/models/cubic/vdW/variants/Berthelot.jl
@@ -93,7 +93,7 @@ function Berthelot(components::Vector{String}; idealmodel=BasicIdeal,
     params = getparams(components, ["properties/critical.csv", "properties/molarmass.csv","SAFT/PCSAFT/PCSAFT_unlike.csv"]; userlocations=userlocations, verbose=verbose)
     k  = get(params,"k",nothing)
     l = get(params,"l",nothing)
-    pc = params["pc"]
+    pc = params["Pc"]
     Mw = params["Mw"]
     Tc = params["Tc"]
     Vc = params["Vc"]

--- a/src/models/cubic/vdW/variants/Clausius.jl
+++ b/src/models/cubic/vdW/variants/Clausius.jl
@@ -81,7 +81,7 @@ function Clausius(components::Vector{String}; idealmodel=BasicIdeal,
     params = getparams(components, ["properties/critical.csv", "properties/molarmass.csv","SAFT/PCSAFT/PCSAFT_unlike.csv"]; userlocations=userlocations, verbose=verbose)
     k  = get(params,"k",nothing)
     l  = get(params,"l",nothing)
-    pc = params["pc"]
+    pc = params["Pc"]
     Vc = params["Vc"]
     Mw = params["Mw"]
     Tc = params["Tc"]

--- a/src/models/cubic/vdW/variants/Clausius.jl
+++ b/src/models/cubic/vdW/variants/Clausius.jl
@@ -31,6 +31,7 @@ end
 ## Input parameters
 - `Tc`: Single Parameter (`Float64`) - Critical Temperature `[K]`
 - `Pc`: Single Parameter (`Float64`) - Critical Pressure `[Pa]`
+- `Vc`: Single Parameter (`Float64`) - Molar Volume `[m^3/mol]`
 - `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g/mol]`
 - `k`: Pair Parameter (`Float64`) (optional)
 - `l`: Pair Parameter (`Float64`) (optional)
@@ -38,6 +39,7 @@ end
 ## Model Parameters
 - `Tc`: Single Parameter (`Float64`) - Critical Temperature `[K]`
 - `Pc`: Single Parameter (`Float64`) - Critical Pressure `[Pa]`
+- `Vc`: Single Parameter (`Float64`) - Molar Volume `[m^3/mol]`
 - `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g/mol]`
 - `a`: Pair Parameter (`Float64`)
 - `b`: Pair Parameter (`Float64`)
@@ -80,7 +82,7 @@ function Clausius(components::Vector{String}; idealmodel=BasicIdeal,
     k  = get(params,"k",nothing)
     l  = get(params,"l",nothing)
     pc = params["pc"]
-    Vc = params["vc"]
+    Vc = params["Vc"]
     Mw = params["Mw"]
     Tc = params["Tc"]
     init_mixing = init_model(mixing,components,activity,mixing_userlocations,activity_userlocations,verbose)

--- a/src/models/cubic/vdW/vdW.jl
+++ b/src/models/cubic/vdW/vdW.jl
@@ -81,7 +81,7 @@ function vdW(components::Vector{String}; idealmodel=BasicIdeal,
     params = getparams(components, ["properties/critical.csv", "properties/molarmass.csv","SAFT/PCSAFT/PCSAFT_unlike.csv"]; userlocations=userlocations, verbose=verbose)
     k  = get(params,"k",nothing)
     l = get(params,"l",nothing)
-    pc = params["pc"]
+    pc = params["Pc"]
     Mw = params["Mw"]
     Tc = params["Tc"]
     init_mixing = init_model(mixing,components,activity,mixing_userlocations,activity_userlocations,verbose)


### PR DESCRIPTION
solves #94. After merging this, 0.4.0 is released.
Breaking changes:
- `x0_sat_pure` now returns `(Vl,Vv)` instead of `(log10(Vl),log10(Vv))`
- `m` -> `segment` (the param name is the same as the database input name)
- `w` -> `acentricfactor` (the param name is the same as the database input name)
- `vc` -> `Vc` (the param name is the same as the database input name)
- `pc` -> `Pc` (the param name is the same as the database input name)
- some stability functions were renamed to `VT_stability` forms.

Pending is the changes to the output of the `tp_flash` method